### PR TITLE
Improve sdf generation performance

### DIFF
--- a/terminus/models/block.py
+++ b/terminus/models/block.py
@@ -6,7 +6,8 @@ class Block(CityModel):
         super(Block, self).__init__(name)
         self.origin = origin
 
-    def template(self):
+    @classmethod
+    def template(cls):
         return """
           <model name="{{model.name}}">
              <static>1</static>

--- a/terminus/models/building.py
+++ b/terminus/models/building.py
@@ -15,7 +15,8 @@ class Building(CityModel):
     def box_base(self):
         return self.origin.z + self.height / 2
 
-    def template(self):
+    @classmethod
+    def template(cls):
         return """
           <model name="{{model.name}}">
              <static>1</static>

--- a/terminus/models/city.py
+++ b/terminus/models/city.py
@@ -22,7 +22,8 @@ class City(CityModel):
     def add_building(self, building):
         self.buildings.append(building)
 
-    def template(self):
+    @classmethod
+    def template(cls):
         return """
         <?xml version="1.0" ?>
         <sdf version="1.5">

--- a/terminus/models/city_element.py
+++ b/terminus/models/city_element.py
@@ -13,8 +13,8 @@ class CityElement(object):
     def cached_jinja_template(cls):
         if not hasattr(cls, '_cached_jinja_template'):
             cls._cached_jinja_template = Template(cls.template(),
-                                                 trim_blocks=True,
-                                                 lstrip_blocks=True)
+                                                  trim_blocks=True,
+                                                  lstrip_blocks=True)
         return cls._cached_jinja_template
 
     def jinja_template(self):

--- a/terminus/models/city_element.py
+++ b/terminus/models/city_element.py
@@ -5,11 +5,20 @@ from jinja2 import Template
 # sdf file
 class CityElement(object):
 
-    def template(self):
+    @classmethod
+    def template(cls):
         raise NotImplementedError()
 
+    @classmethod
+    def cached_jinja_template(cls):
+        if not hasattr(cls, '_cached_jinja_template'):
+            cls._cached_jinja_template = Template(cls.template(),
+                                                 trim_blocks=True,
+                                                 lstrip_blocks=True)
+        return cls._cached_jinja_template
+
+    def jinja_template(self):
+        return self.cached_jinja_template()
+
     def to_sdf(self):
-        template = Template(self.template(),
-                            trim_blocks=True,
-                            lstrip_blocks=True)
-        return template.render(model=self)
+        return self.jinja_template().render(model=self)

--- a/terminus/models/ground_plane.py
+++ b/terminus/models/ground_plane.py
@@ -7,7 +7,8 @@ class GroundPlane(CityModel):
         self.size = size
         self.origin = origin
 
-    def template(self):
+    @classmethod
+    def template(cls):
         return """
           <model name="{{model.name}}">
             <static>1</static>

--- a/terminus/models/point.py
+++ b/terminus/models/point.py
@@ -7,5 +7,6 @@ class Point(CityElement):
         self.y = y
         self.z = z
 
-    def template(self):
+    @classmethod
+    def template(cls):
         return "<point>{{model.x}} {{model.y}} {{model.z}}</point>"

--- a/terminus/models/road.py
+++ b/terminus/models/road.py
@@ -13,7 +13,8 @@ class Road(CityModel):
     def material_name(self):
         raise NotImplementedError()
 
-    def template(self):
+    @classmethod
+    def template(cls):
         return """
           <road name="{{model.name}}">
             <width>{{model.width}}</width>


### PR DESCRIPTION
Fixes #12 

Basically just caching the Jinja template so it doesn't need to parse it over and over. Time has drastically changed:

```
$ time terminus/run_generator.py --builder=ProceduralCityBuilder --destination=hey.world --parameters filename=../procedural_city_generation/procedural_city_generation/temp/mycity
```

Before:
```
real 0m11.854s
user 0m11.768s
sys  0m0.024s
```

After:
```
real 0m0.464s
user 0m0.408s
sys  0m0.052s
```

@ernestmc @garyservin the only important thing to remember is that now the `template()` method lives on the class side, so you should define it like:

```
    @classmethod
    def template(cls):
        ...
```

If we happen to need to redefine the template at the instance level (can't think why, but in any case) you can just override the instance method `jinja_template(self)`. You will however loose the caching.