### PR TITLE
Distinguish trunk streets

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,12 @@ Currently the idea is to have a single, unified City model that knows how to con
 
 - `SimpleCityBuilder`, which generates a squared city based on a configurable size.
 - `ProceduralCityBuilder`, which takes the output file(s) produced by https://github.com/josauder/procedural_city_generation and uses that to build the city model.
+
+## About street and trunk generation
+
+The output of the PCG is a list of vertices with a `minor_road` property. Each vertex has a list of neighbouring vertices.
+If a vertex is marked as `minor_road == true` then we start building a street else if `minor_road == false` we start building a trunk. We then check the list of neighbours and choose the best one with the following criteria:
+
+- Prefer continue building a road of the same type (street or trunk). Trunks can only be built between vertices of type trunk (`minor_road` == false). Streets can eventually end in a trunk vertex, which is interpreted as an access to the highway.
+- Prefer neighbours which substend a similar angle to the current road segment and are below a maximum threshold.
+If these conditions are not met then the current roads stops growing.

--- a/terminus/builders/procedural_city/vertex.py
+++ b/terminus/builders/procedural_city/vertex.py
@@ -8,7 +8,7 @@ class Vertex(object):
     def __init__(self, coords):
         self.coords = coords
         self.neighbours = []
-        self.minor_road = False
+        self.minor_road = True
         self.seed = False
 
     def __repr__(self):

--- a/terminus/builders/procedural_city/vertex_graph_to_roads_converter.py
+++ b/terminus/builders/procedural_city/vertex_graph_to_roads_converter.py
@@ -46,7 +46,7 @@ class VertexGraphToRoadsConverter(object):
             # Since there is a previous vertex, we must select the
             # best of the neighbours.
             best_neighbour = self._pick_best_neighbour(previous_vertex,
-                                                  current_vertex)
+                                                       current_vertex)
             if best_neighbour is not None:
                 current_vertex.neighbours.remove(best_neighbour)
                 if current_vertex in best_neighbour.neighbours:
@@ -67,6 +67,8 @@ class VertexGraphToRoadsConverter(object):
         We order the edges according to their angle with the current edge and
         we select the vertex with the lowest angle and check if it's below the
         threshold. Also we prefer continuing the same type of road.
+        Trunks can only start and end on trunk vertices (`minor_road` == false).
+        Streets can eventually end on a trunk vertex.
         """
         current_angle = self._angle_2d(previous_vertex.coords,
                                        current_vertex.coords)

--- a/terminus/builders/procedural_city/vertex_graph_to_roads_converter.py
+++ b/terminus/builders/procedural_city/vertex_graph_to_roads_converter.py
@@ -63,22 +63,22 @@ class VertexGraphToRoadsConverter(object):
                     selected_neighbour = edge[0]
                     # Prefer building the same type of road in first place
                     if current_vertex.minor_road == \
-                       selected_neighbour.minor_road:
-                       first_option = selected_neighbour
-                       break
+                            selected_neighbour.minor_road:
+                        first_option = selected_neighbour
+                        break
                     # Prefer connecting a street to a trunk in second place
                     if current_vertex.minor_road and \
-                       not selected_neighbour.minor_road and \
-                       second_option == None:
-                       second_option = selected_neighbour
+                            not selected_neighbour.minor_road and \
+                            second_option is None:
+                        second_option = selected_neighbour
             # If we've got some options, use the best one
             best_neighbour = None
-            if first_option != None:
+            if first_option is not None:
                 best_neighbour = first_option
             else:
-                if second_option != None:
+                if second_option is not None:
                     best_neighbour = second_option
-            if best_neighbour != None:
+            if best_neighbour is not None:
                 current_vertex.neighbours.remove(best_neighbour)
                 if current_vertex in best_neighbour.neighbours:
                     best_neighbour.neighbours.remove(current_vertex)

--- a/terminus/builders/procedural_city/vertex_graph_to_roads_converter.py
+++ b/terminus/builders/procedural_city/vertex_graph_to_roads_converter.py
@@ -19,11 +19,13 @@ class VertexGraphToRoadsConverter(object):
                                  key=lambda vertex: len(vertex.neighbours))
             vertex = to_traverse.pop(0)
             while vertex.neighbours:
-                street = Street()
-                street.width = 5
-                street.add_point(vertex.coords)
-                self._build_road(street, None, vertex)
-                roads.append(street)
+                if vertex.minor_road:
+                    road = Street()
+                else:
+                    road = Trunk()
+                road.add_point(vertex.coords)
+                self._build_road(road, None, vertex)
+                roads.append(road)
         return roads
 
     def _build_road(self, street, previous_vertex, current_vertex):

--- a/terminus/builders/simple_city_builder.py
+++ b/terminus/builders/simple_city_builder.py
@@ -56,22 +56,22 @@ class SimpleCityBuilder(object):
         city.add_road(road)
 
     def _create_surrounding_ring_road(self, city, size):
-        ring_road_1 = Street('RingRoad1')
+        ring_road_1 = Street(name='RingRoad1')
         ring_road_1.add_point(Point(-2.5, 0, 0))
         ring_road_1.add_point(Point(size * 100 + 2.5, 0, 0))
         city.add_road(ring_road_1)
 
-        ring_road_2 = Street('RingRoad2')
+        ring_road_2 = Street(name='RingRoad2')
         ring_road_2.add_point(Point(size * 100, 0, 0))
         ring_road_2.add_point(Point(size * 100, size * 100, 0))
         city.add_road(ring_road_2)
 
-        ring_road_3 = Street('RingRoad3')
+        ring_road_3 = Street(name='RingRoad3')
         ring_road_3.add_point(Point(-2.5, size * 100, 0))
         ring_road_3.add_point(Point(size * 100 + 2.5, size * 100, 0))
         city.add_road(ring_road_3)
 
-        ring_road_4 = Street('RingRoad4')
+        ring_road_4 = Street(name='RingRoad4')
         ring_road_4.add_point(Point(0, 0, 0))
         ring_road_4.add_point(Point(0, size * 100, 0))
         city.add_road(ring_road_4)

--- a/terminus/models/road.py
+++ b/terminus/models/road.py
@@ -19,7 +19,7 @@ class Road(CityModel):
 
     def points_count(self):
         return len(self.points)
-        
+
     def get_width(self):
         return width
 

--- a/terminus/models/road.py
+++ b/terminus/models/road.py
@@ -9,7 +9,7 @@ class Road(CityModel):
 
     @classmethod
     def from_points(cls, array_of_points):
-        road = cls(cls.default_width())
+        road = cls()
         for point in array_of_points:
             road.add_point(point)
         return road
@@ -19,6 +19,12 @@ class Road(CityModel):
 
     def points_count(self):
         return len(self.points)
+        
+    def get_width(self):
+        return width
+
+    def set_width(self, width):
+        self.width = width
 
     def __eq__(self, other):
         return (self.__class__ == other.__class__) and \
@@ -32,5 +38,5 @@ class Road(CityModel):
         return hash(tuple(sorted(self.__dict__.items())))
 
     def __repr__(self):
-        return "Road: " + reduce(lambda acc, point: acc + str(point),
-                                 self.points, '')
+        return "%s: " % self.__class__ + reduce(lambda acc, point: acc +
+               "%s," % str(point), self.points, '')

--- a/terminus/models/road.py
+++ b/terminus/models/road.py
@@ -39,4 +39,5 @@ class Road(CityModel):
 
     def __repr__(self):
         return "%s: " % self.__class__ + reduce(lambda acc, point: acc +
-               "%s," % str(point), self.points, '')
+                                                "%s," % str(point),
+                                                self.points, '')

--- a/terminus/models/street.py
+++ b/terminus/models/street.py
@@ -2,12 +2,8 @@ from road import Road
 
 
 class Street(Road):
-    def __init__(self, name=None):
-        super(Street, self).__init__(self.default_width(), name)
-
-    @classmethod
-    def default_width(cls):
-        return 5
+    def __init__(self, width=5, name=None):
+        super(Street, self).__init__(width, name)
 
     def accept(self, generator):
         generator.start_street(self)

--- a/terminus/models/trunk.py
+++ b/terminus/models/trunk.py
@@ -2,12 +2,8 @@ from road import Road
 
 
 class Trunk(Road):
-    def __init__(self, name=None):
-        super(Trunk, self).__init__(self.default_width(), name)
-
-    @classmethod
-    def default_width(cls):
-        return 10
+    def __init__(self, width=10, name=None):
+        super(Trunk, self).__init__(width, name)
 
     def accept(self, generator):
         generator.start_trunk(self)

--- a/terminus/tests/vertex_graph_to_roads_converter_test.py
+++ b/terminus/tests/vertex_graph_to_roads_converter_test.py
@@ -261,7 +261,7 @@ class VertexGraphToRoadsConverterTest(unittest.TestCase):
         v2 = Vertex(Point(1, 0))
         v3 = Vertex(Point(6, 1))
         v4 = Vertex(Point(6, -0.8))
-        v4.minor_road = False # make trunk
+        v4.minor_road = False  # make trunk
 
         self._connect(v1, v2)
         self._connect(v2, v3)

--- a/terminus/tests/vertex_graph_to_roads_converter_test.py
+++ b/terminus/tests/vertex_graph_to_roads_converter_test.py
@@ -6,6 +6,8 @@ from shapely.geometry import Point
 from models.street import Street
 from models.trunk import Trunk
 
+STREET_WIDTH = 4
+
 
 class VertexGraphToRoadsConverterTest(unittest.TestCase):
 
@@ -17,12 +19,11 @@ class VertexGraphToRoadsConverterTest(unittest.TestCase):
         v2 = Vertex(Point(1, 0))
 
         self._connect(v1, v2)
-
         self.converter = VertexGraphToRoadsConverter(0.25, [v1, v2])
         roads = self.converter.get_roads()
-        expected_roads = [
-            Street.from_points([Point(0, 0), Point(1, 0)])
-        ]
+        street = Street.from_points([Point(0, 0), Point(1, 0)])
+        street.set_width(STREET_WIDTH)
+        expected_roads = [street]
         self.assertItemsEqual(roads, expected_roads)
 
     def test_get_roads_one_not_aligned_segment(self):
@@ -38,9 +39,9 @@ class VertexGraphToRoadsConverterTest(unittest.TestCase):
 
         self.converter = VertexGraphToRoadsConverter(0.25, [v1, v2])
         roads = self.converter.get_roads()
-        expected_roads = [
-            Street.from_points([Point(0, 0), Point(1, 1)])
-        ]
+        street = Street.from_points([Point(0, 0), Point(1, 1)])
+        street.set_width(STREET_WIDTH)
+        expected_roads = [street]
         self.assertItemsEqual(roads, expected_roads)
 
     def test_get_roads_multiple_aligned_segments(self):
@@ -58,10 +59,10 @@ class VertexGraphToRoadsConverterTest(unittest.TestCase):
 
         self.converter = VertexGraphToRoadsConverter(0.25, [v1, v2, v3, v4])
         roads = self.converter.get_roads()
-        expected_roads = [
-            Street.from_points(
-                [Point(0, 0), Point(1, 0), Point(5, 1), Point(9, 3)])
-        ]
+        street = Street.from_points([Point(0, 0), Point(1, 0), Point(5, 1),
+                                    Point(9, 3)])
+        street.set_width(STREET_WIDTH)
+        expected_roads = [street]
         self.assertItemsEqual(roads, expected_roads)
 
     def test_get_roads_multiple_non_aligned_segments(self):
@@ -80,10 +81,13 @@ class VertexGraphToRoadsConverterTest(unittest.TestCase):
 
         self.converter = VertexGraphToRoadsConverter(0.25, [v1, v2, v3, v4])
         roads = self.converter.get_roads()
-        expected_roads = [
-            Street.from_points([Point(0, 0), Point(1, 0), Point(5, 1)]),
-            Street.from_points([Point(6, 2), Point(5, 1)])
-        ]
+        expected_roads = []
+        street = Street.from_points([Point(0, 0), Point(1, 0), Point(5, 1)])
+        street.set_width(STREET_WIDTH)
+        expected_roads.append(street)
+        street = Street.from_points([Point(6, 2), Point(5, 1)])
+        street.set_width(STREET_WIDTH)
+        expected_roads.append(street)
         self.assertItemsEqual(roads, expected_roads)
 
     def test_get_roads_multiple_independent_segments(self):
@@ -104,10 +108,13 @@ class VertexGraphToRoadsConverterTest(unittest.TestCase):
         self.converter = VertexGraphToRoadsConverter(
             0.25, [v1, v2, v3, v4, v5])
         roads = self.converter.get_roads()
-        expected_roads = [
-            Street.from_points([Point(0, 0), Point(1, 0), Point(6, 1)]),
-            Street.from_points([Point(2, 5), Point(3, 4)])
-        ]
+        expected_roads = []
+        street = Street.from_points([Point(0, 0), Point(1, 0), Point(6, 1)])
+        street.set_width(STREET_WIDTH)
+        expected_roads.append(street)
+        street = Street.from_points([Point(2, 5), Point(3, 4)])
+        street.set_width(STREET_WIDTH)
+        expected_roads.append(street)
         self.assertItemsEqual(roads, expected_roads)
 
     def test_get_roads_V_type(self):
@@ -124,10 +131,13 @@ class VertexGraphToRoadsConverterTest(unittest.TestCase):
 
         self.converter = VertexGraphToRoadsConverter(0.25, [v1, v2, v3])
         roads = self.converter.get_roads()
-        expected_roads = [
-            Street.from_points([Point(3, -1), Point(0, 0)]),
-            Street.from_points([Point(3, 1), Point(0, 0)])
-        ]
+        expected_roads = []
+        street = Street.from_points([Point(3, -1), Point(0, 0)])
+        street.set_width(STREET_WIDTH)
+        expected_roads.append(street)
+        street = Street.from_points([Point(3, 1), Point(0, 0)])
+        street.set_width(STREET_WIDTH)
+        expected_roads.append(street)
         self.assertItemsEqual(roads, expected_roads)
 
     def test_get_roads_L_type(self):
@@ -147,10 +157,13 @@ class VertexGraphToRoadsConverterTest(unittest.TestCase):
 
         self.converter = VertexGraphToRoadsConverter(0.25, [v1, v2, v3, v4])
         roads = self.converter.get_roads()
-        expected_roads = [
-            Street.from_points([Point(0, 0), Point(1, 0), Point(6, 1)]),
-            Street.from_points([Point(6, 6), Point(1, 0)])
-        ]
+        expected_roads = []
+        street = Street.from_points([Point(0, 0), Point(1, 0), Point(6, 1)])
+        street.set_width(STREET_WIDTH)
+        expected_roads.append(street)
+        street = Street.from_points([Point(6, 6), Point(1, 0)])
+        street.set_width(STREET_WIDTH)
+        expected_roads.append(street)
         self.assertItemsEqual(roads, expected_roads)
 
     def test_get_roads_Y_type(self):
@@ -171,10 +184,13 @@ class VertexGraphToRoadsConverterTest(unittest.TestCase):
 
         self.converter = VertexGraphToRoadsConverter(0.25, [v1, v2, v3, v4])
         roads = self.converter.get_roads()
-        expected_roads = [
-            Street.from_points([Point(0, 0), Point(1, 0), Point(6, -0.8)]),
-            Street.from_points([Point(6, 1), Point(1, 0)])
-        ]
+        expected_roads = []
+        street = Street.from_points([Point(0, 0), Point(1, 0), Point(6, -0.8)])
+        street.set_width(STREET_WIDTH)
+        expected_roads.append(street)
+        street = Street.from_points([Point(6, 1), Point(1, 0)])
+        street.set_width(STREET_WIDTH)
+        expected_roads.append(street)
         self.assertItemsEqual(roads, expected_roads)
 
     def test_get_roads_matrix_distribution(self):
@@ -213,14 +229,25 @@ class VertexGraphToRoadsConverterTest(unittest.TestCase):
         self.converter = VertexGraphToRoadsConverter(
             0.25, [v1, v2, v3, v4, v5, v6, v7, v8, v9])
         roads = self.converter.get_roads()
-        expected_roads = [
-            Street.from_points([Point(0, 0), Point(0, 1), Point(0, 2)]),
-            Street.from_points([Point(1, 0), Point(1, 1), Point(1, 2)]),
-            Street.from_points([Point(2, 0), Point(2, 1), Point(2, 2)]),
-            Street.from_points([Point(0, 0), Point(1, 0), Point(2, 0)]),
-            Street.from_points([Point(0, 1), Point(1, 1), Point(2, 1)]),
-            Street.from_points([Point(0, 2), Point(1, 2), Point(2, 2)])
-        ]
+        expected_roads = []
+        street = Street.from_points([Point(0, 0), Point(0, 1), Point(0, 2)])
+        street.set_width(STREET_WIDTH)
+        expected_roads.append(street)
+        street = Street.from_points([Point(1, 0), Point(1, 1), Point(1, 2)])
+        street.set_width(STREET_WIDTH)
+        expected_roads.append(street)
+        street = Street.from_points([Point(2, 0), Point(2, 1), Point(2, 2)])
+        street.set_width(STREET_WIDTH)
+        expected_roads.append(street)
+        street = Street.from_points([Point(0, 0), Point(1, 0), Point(2, 0)])
+        street.set_width(STREET_WIDTH)
+        expected_roads.append(street)
+        street = Street.from_points([Point(0, 1), Point(1, 1), Point(2, 1)])
+        street.set_width(STREET_WIDTH)
+        expected_roads.append(street)
+        street = Street.from_points([Point(0, 2), Point(1, 2), Point(2, 2)])
+        street.set_width(STREET_WIDTH)
+        expected_roads.append(street)
         self.assertItemsEqual(roads, expected_roads)
 
     def _connect(self, v1, v2):

--- a/terminus/tests/vertex_graph_to_roads_converter_test.py
+++ b/terminus/tests/vertex_graph_to_roads_converter_test.py
@@ -7,6 +7,7 @@ from models.street import Street
 from models.trunk import Trunk
 
 STREET_WIDTH = 4
+TRUNK_WIDTH = 22
 
 
 class VertexGraphToRoadsConverterTest(unittest.TestCase):
@@ -19,11 +20,13 @@ class VertexGraphToRoadsConverterTest(unittest.TestCase):
         v2 = Vertex(Point(1, 0))
 
         self._connect(v1, v2)
+
         self.converter = VertexGraphToRoadsConverter(0.25, [v1, v2])
         roads = self.converter.get_roads()
-        street = Street.from_points([Point(0, 0), Point(1, 0)])
-        street.set_width(STREET_WIDTH)
-        expected_roads = [street]
+        expected_roads = [
+            Street.from_points([Point(0, 0), Point(1, 0)])
+        ]
+        self._set_roads_width(expected_roads)
         self.assertItemsEqual(roads, expected_roads)
 
     def test_get_roads_one_not_aligned_segment(self):
@@ -39,9 +42,10 @@ class VertexGraphToRoadsConverterTest(unittest.TestCase):
 
         self.converter = VertexGraphToRoadsConverter(0.25, [v1, v2])
         roads = self.converter.get_roads()
-        street = Street.from_points([Point(0, 0), Point(1, 1)])
-        street.set_width(STREET_WIDTH)
-        expected_roads = [street]
+        expected_roads = [
+            Street.from_points([Point(0, 0), Point(1, 1)])
+        ]
+        self._set_roads_width(expected_roads)
         self.assertItemsEqual(roads, expected_roads)
 
     def test_get_roads_multiple_aligned_segments(self):
@@ -59,10 +63,11 @@ class VertexGraphToRoadsConverterTest(unittest.TestCase):
 
         self.converter = VertexGraphToRoadsConverter(0.25, [v1, v2, v3, v4])
         roads = self.converter.get_roads()
-        street = Street.from_points([Point(0, 0), Point(1, 0), Point(5, 1),
-                                    Point(9, 3)])
-        street.set_width(STREET_WIDTH)
-        expected_roads = [street]
+        expected_roads = [
+            Street.from_points(
+                [Point(0, 0), Point(1, 0), Point(5, 1), Point(9, 3)])
+        ]
+        self._set_roads_width(expected_roads)
         self.assertItemsEqual(roads, expected_roads)
 
     def test_get_roads_multiple_non_aligned_segments(self):
@@ -81,13 +86,11 @@ class VertexGraphToRoadsConverterTest(unittest.TestCase):
 
         self.converter = VertexGraphToRoadsConverter(0.25, [v1, v2, v3, v4])
         roads = self.converter.get_roads()
-        expected_roads = []
-        street = Street.from_points([Point(0, 0), Point(1, 0), Point(5, 1)])
-        street.set_width(STREET_WIDTH)
-        expected_roads.append(street)
-        street = Street.from_points([Point(6, 2), Point(5, 1)])
-        street.set_width(STREET_WIDTH)
-        expected_roads.append(street)
+        expected_roads = [
+            Street.from_points([Point(0, 0), Point(1, 0), Point(5, 1)]),
+            Street.from_points([Point(6, 2), Point(5, 1)])
+        ]
+        self._set_roads_width(expected_roads)
         self.assertItemsEqual(roads, expected_roads)
 
     def test_get_roads_multiple_independent_segments(self):
@@ -108,13 +111,11 @@ class VertexGraphToRoadsConverterTest(unittest.TestCase):
         self.converter = VertexGraphToRoadsConverter(
             0.25, [v1, v2, v3, v4, v5])
         roads = self.converter.get_roads()
-        expected_roads = []
-        street = Street.from_points([Point(0, 0), Point(1, 0), Point(6, 1)])
-        street.set_width(STREET_WIDTH)
-        expected_roads.append(street)
-        street = Street.from_points([Point(2, 5), Point(3, 4)])
-        street.set_width(STREET_WIDTH)
-        expected_roads.append(street)
+        expected_roads = [
+            Street.from_points([Point(0, 0), Point(1, 0), Point(6, 1)]),
+            Street.from_points([Point(2, 5), Point(3, 4)])
+        ]
+        self._set_roads_width(expected_roads)
         self.assertItemsEqual(roads, expected_roads)
 
     def test_get_roads_V_type(self):
@@ -131,13 +132,11 @@ class VertexGraphToRoadsConverterTest(unittest.TestCase):
 
         self.converter = VertexGraphToRoadsConverter(0.25, [v1, v2, v3])
         roads = self.converter.get_roads()
-        expected_roads = []
-        street = Street.from_points([Point(3, -1), Point(0, 0)])
-        street.set_width(STREET_WIDTH)
-        expected_roads.append(street)
-        street = Street.from_points([Point(3, 1), Point(0, 0)])
-        street.set_width(STREET_WIDTH)
-        expected_roads.append(street)
+        expected_roads = [
+            Street.from_points([Point(3, -1), Point(0, 0)]),
+            Street.from_points([Point(3, 1), Point(0, 0)])
+        ]
+        self._set_roads_width(expected_roads)
         self.assertItemsEqual(roads, expected_roads)
 
     def test_get_roads_L_type(self):
@@ -157,13 +156,11 @@ class VertexGraphToRoadsConverterTest(unittest.TestCase):
 
         self.converter = VertexGraphToRoadsConverter(0.25, [v1, v2, v3, v4])
         roads = self.converter.get_roads()
-        expected_roads = []
-        street = Street.from_points([Point(0, 0), Point(1, 0), Point(6, 1)])
-        street.set_width(STREET_WIDTH)
-        expected_roads.append(street)
-        street = Street.from_points([Point(6, 6), Point(1, 0)])
-        street.set_width(STREET_WIDTH)
-        expected_roads.append(street)
+        expected_roads = [
+            Street.from_points([Point(0, 0), Point(1, 0), Point(6, 1)]),
+            Street.from_points([Point(6, 6), Point(1, 0)])
+        ]
+        self._set_roads_width(expected_roads)
         self.assertItemsEqual(roads, expected_roads)
 
     def test_get_roads_Y_type(self):
@@ -184,13 +181,11 @@ class VertexGraphToRoadsConverterTest(unittest.TestCase):
 
         self.converter = VertexGraphToRoadsConverter(0.25, [v1, v2, v3, v4])
         roads = self.converter.get_roads()
-        expected_roads = []
-        street = Street.from_points([Point(0, 0), Point(1, 0), Point(6, -0.8)])
-        street.set_width(STREET_WIDTH)
-        expected_roads.append(street)
-        street = Street.from_points([Point(6, 1), Point(1, 0)])
-        street.set_width(STREET_WIDTH)
-        expected_roads.append(street)
+        expected_roads = [
+            Street.from_points([Point(0, 0), Point(1, 0), Point(6, -0.8)]),
+            Street.from_points([Point(6, 1), Point(1, 0)])
+        ]
+        self._set_roads_width(expected_roads)
         self.assertItemsEqual(roads, expected_roads)
 
     def test_get_roads_matrix_distribution(self):
@@ -229,33 +224,23 @@ class VertexGraphToRoadsConverterTest(unittest.TestCase):
         self.converter = VertexGraphToRoadsConverter(
             0.25, [v1, v2, v3, v4, v5, v6, v7, v8, v9])
         roads = self.converter.get_roads()
-        expected_roads = []
-        street = Street.from_points([Point(0, 0), Point(0, 1), Point(0, 2)])
-        street.set_width(STREET_WIDTH)
-        expected_roads.append(street)
-        street = Street.from_points([Point(1, 0), Point(1, 1), Point(1, 2)])
-        street.set_width(STREET_WIDTH)
-        expected_roads.append(street)
-        street = Street.from_points([Point(2, 0), Point(2, 1), Point(2, 2)])
-        street.set_width(STREET_WIDTH)
-        expected_roads.append(street)
-        street = Street.from_points([Point(0, 0), Point(1, 0), Point(2, 0)])
-        street.set_width(STREET_WIDTH)
-        expected_roads.append(street)
-        street = Street.from_points([Point(0, 1), Point(1, 1), Point(2, 1)])
-        street.set_width(STREET_WIDTH)
-        expected_roads.append(street)
-        street = Street.from_points([Point(0, 2), Point(1, 2), Point(2, 2)])
-        street.set_width(STREET_WIDTH)
-        expected_roads.append(street)
+        expected_roads = [
+            Street.from_points([Point(0, 0), Point(0, 1), Point(0, 2)]),
+            Street.from_points([Point(1, 0), Point(1, 1), Point(1, 2)]),
+            Street.from_points([Point(2, 0), Point(2, 1), Point(2, 2)]),
+            Street.from_points([Point(0, 0), Point(1, 0), Point(2, 0)]),
+            Street.from_points([Point(0, 1), Point(1, 1), Point(2, 1)]),
+            Street.from_points([Point(0, 2), Point(1, 2), Point(2, 2)])
+        ]
+        self._set_roads_width(expected_roads)
         self.assertItemsEqual(roads, expected_roads)
 
-    def test_get_roads_Y_street_and_trunk_type(self):
+    def test_get_roads_Y_street_best_neighbour_trunk(self):
         """
         (0,0)--(1,0)--(6,1)
                   |---(6,-0.8)(trunk)
-        Note that (6,-0.8) is discarded because it's a trunk even though it has
-        a has a smaller angle but we are building a street type.
+        Expected: main street:[(0,0),(1,0),(6,1)]
+                  access street:[(1,0), (6,-0.8)]
         """
         v1 = Vertex(Point(0, 0))
         v2 = Vertex(Point(1, 0))
@@ -269,16 +254,95 @@ class VertexGraphToRoadsConverterTest(unittest.TestCase):
 
         self.converter = VertexGraphToRoadsConverter(0.25, [v1, v2, v3, v4])
         roads = self.converter.get_roads()
-        expected_roads = []
-        street = Street.from_points([Point(0, 0), Point(1, 0), Point(6, 1)])
-        street.set_width(STREET_WIDTH)
-        expected_roads.append(street)
-        street = Street.from_points([Point(1, 0), Point(6, -0.8)])
-        street.set_width(STREET_WIDTH)
-        expected_roads.append(street)
+        expected_roads = [
+            Street.from_points([Point(0, 0), Point(1, 0), Point(6, 1)]),
+            Street.from_points([Point(1, 0), Point(6, -0.8)])
+        ]
+        self._set_roads_width(expected_roads)
+        self.assertItemsEqual(roads, expected_roads)
+
+    def test_get_roads_Y_street_best_neighbour_street(self):
+        """
+        (0,0)--(1,0)--(6,1)(trunk)
+                  |---(6,-0.8)
+        Expected: main street:[(0,0),(1,0),(6,-0.8)]
+                  access street:[(1,0), (6,1)]
+        """
+        v1 = Vertex(Point(0, 0))
+        v2 = Vertex(Point(1, 0))
+        v3 = Vertex(Point(6, 1))
+        v3.minor_road = False  # make trunk
+        v4 = Vertex(Point(6, -0.8))
+
+        self._connect(v1, v2)
+        self._connect(v2, v3)
+        self._connect(v2, v4)
+
+        self.converter = VertexGraphToRoadsConverter(0.25, [v1, v2, v3, v4])
+        roads = self.converter.get_roads()
+        expected_roads = [
+            Street.from_points([Point(0, 0), Point(1, 0), Point(6, -0.8)]),
+            Street.from_points([Point(1, 0), Point(6, 1)])
+        ]
+        self._set_roads_width(expected_roads)
+        self.assertItemsEqual(roads, expected_roads)
+
+    def test_get_roads_pipe_street_into_trunk(self):
+        """
+        (0,0)--(1,0)--(6,0)(trunk)
+        Expected: main street:[(0,0),(1,0),(6,0)]
+        """
+        v1 = Vertex(Point(0, 0))
+        v2 = Vertex(Point(1, 0))
+        v3 = Vertex(Point(6, 0))
+        v3.minor_road = False  # make trunk
+
+        self._connect(v1, v2)
+        self._connect(v2, v3)
+
+        self.converter = VertexGraphToRoadsConverter(0.25, [v1, v2, v3])
+        roads = self.converter.get_roads()
+        expected_roads = [
+            Street.from_points([Point(0, 0), Point(1, 0), Point(6, 0)])
+        ]
+        self._set_roads_width(expected_roads)
+        self.assertItemsEqual(roads, expected_roads)
+
+    def test_get_roads_pipe_trunk_into_street(self):
+        """
+        (0,0)(trunk)--(1,0)(trunk)--(6,0)
+        Expected: trunk:[(0,0),(1,0)]
+                  access street:[(6,0),(1,0)]
+        """
+        v1 = Vertex(Point(0, 0))
+        v1.minor_road = False  # make trunk
+        v2 = Vertex(Point(1, 0))
+        v2.minor_road = False  # make trunk
+        v3 = Vertex(Point(6, 0))
+
+        self._connect(v1, v2)
+        self._connect(v2, v3)
+
+        self.converter = VertexGraphToRoadsConverter(0.25, [v1, v2, v3])
+        roads = self.converter.get_roads()
+        expected_roads = [
+            Trunk.from_points([Point(0, 0), Point(1, 0)]),
+            Street.from_points([Point(6, 0), Point(1, 0)])
+        ]
+        self._set_roads_width(expected_roads)
         self.assertItemsEqual(roads, expected_roads)
 
     def _connect(self, v1, v2):
         """Make a bidirectional connection between two vertices"""
         v1.neighbours.append(v2)
         v2.neighbours.append(v1)
+
+    def _set_roads_width(self, roads):
+        """
+        Set the width to a list of roads.
+        """
+        for road in roads:
+            if type(road) is Street:
+                road.set_width(STREET_WIDTH)
+            if type(road) is Trunk:
+                road.set_width(TRUNK_WIDTH)

--- a/terminus/tests/vertex_graph_to_roads_converter_test.py
+++ b/terminus/tests/vertex_graph_to_roads_converter_test.py
@@ -250,6 +250,34 @@ class VertexGraphToRoadsConverterTest(unittest.TestCase):
         expected_roads.append(street)
         self.assertItemsEqual(roads, expected_roads)
 
+    def test_get_roads_Y_street_and_trunk_type(self):
+        """
+        (0,0)--(1,0)--(6,1)
+                  |---(6,-0.8)(trunk)
+        Note that (6,-0.8) is discarded because it's a trunk even though it has
+        a has a smaller angle but we are building a street type.
+        """
+        v1 = Vertex(Point(0, 0))
+        v2 = Vertex(Point(1, 0))
+        v3 = Vertex(Point(6, 1))
+        v4 = Vertex(Point(6, -0.8))
+        v4.minor_road = False # make trunk
+
+        self._connect(v1, v2)
+        self._connect(v2, v3)
+        self._connect(v2, v4)
+
+        self.converter = VertexGraphToRoadsConverter(0.25, [v1, v2, v3, v4])
+        roads = self.converter.get_roads()
+        expected_roads = []
+        street = Street.from_points([Point(0, 0), Point(1, 0), Point(6, 1)])
+        street.set_width(STREET_WIDTH)
+        expected_roads.append(street)
+        street = Street.from_points([Point(1, 0), Point(6, -0.8)])
+        street.set_width(STREET_WIDTH)
+        expected_roads.append(street)
+        self.assertItemsEqual(roads, expected_roads)
+
     def _connect(self, v1, v2):
         """Make a bidirectional connection between two vertices"""
         v1.neighbours.append(v2)


### PR DESCRIPTION
Addresses issue #22.
- Create a `Street` or a `Trunk` based on the first vertex.
- Continue building a `Trunk` only if the next vertex also belongs to a `Trunk`.
- A `Street` can end in a `Trunk` but a `Trunk` cannot end in a `Street`.

Screenshots:
![screenshot from 2016-10-21 17 31 45](https://cloud.githubusercontent.com/assets/9289769/19611702/4d9917e6-97b9-11e6-9db5-4741bd2e36f1.png)
![screenshot from 2016-10-21 17 32 50](https://cloud.githubusercontent.com/assets/9289769/19611704/4fc39a64-97b9-11e6-9f12-cba957c5db4a.png)
![screenshot from 2016-10-21 17 33 31](https://cloud.githubusercontent.com/assets/9289769/19611705/51c44b88-97b9-11e6-9d8d-d4f5e743df88.png)
