### PR TITLE
Seamlessly incorporate procedural_city_generation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "terminus/procedural_city_generation"]
+	path = terminus/procedural_city_generation
+	url = https://github.com/josauder/procedural_city_generation.git

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ Library to procedurally create cities and terrains
 - Execute `$ terminus/run_generator.py` to create a new city. In order for the generator to run you **must** specify the builder to use (and its required constructor values). You can optionally specify the output file (if none specified the output will be written to `generated_worlds/city.world`).
 Some examples:
 
-    * Get help: `$ terminus/run_generator.py -h` 
+    * Get help: `$ terminus/run_generator.py -h`
     * Generate using the simple city builder `$ terminus/run_generator.py --builder=SimpleCityBuilder`
     * Specify the output file `$ terminus/run_generator.py --builder=SimpleCityBuilder --destination=demo_city.world`
-    * Generate the city using the output file from the `procedural_city_generation` package $ terminus/run_generator.py --builder=ProceduralCityBuilder --parameters verticesFilename=../procedural_city_generation/procedural_city_generation/temp/mycity polygonsFilename=../procedural_city_generation/procedural_city_generation/temp/mycity_polygons.txt`    
+    * Generate the city using the `procedural_city_generation` package $ terminus/run_generator.py --builder=ProceduralCityBuilder --parameters size=1500
 
 - Open using `$ gazebo generated_worlds/city.world`
 
@@ -19,4 +19,4 @@ Some examples:
 Currently the idea is to have a single, unified City model that knows how to convert itself to an sdf file and that can be generated in different ways. These different ways of building cities are captured in the "builder" classes, which so far are two:
 
 - `SimpleCityBuilder`, which generates a squared city based on a configurable size.
-- `ProceduralCityBuilder`, which takes the output file(s) produced by https://github.com/josauder/procedural_city_generation and uses that to build the city model. In order to use that builder you need to first clone the repository mentioned above and make sure it runs fine. Once it is setup you can just run `python UI.py "roadmap" "run"` and it will generate the file `procedural_city_generation/temp/mycity` which you can feed to our generator script (we will later include this step in the generator itself).
+- `ProceduralCityBuilder`, which takes the output file(s) produced by https://github.com/josauder/procedural_city_generation and uses that to build the city model.

--- a/terminus/builders/procedural_city_builder.py
+++ b/terminus/builders/procedural_city_builder.py
@@ -30,7 +30,7 @@ class ProceduralCityBuilder(object):
         self.verticesFilename = verticesFilename
         self.polygonsFilename = polygonsFilename
         self.ratio = 100  # ratio between pcg and gazebo (1unit = 100m)
-        self.size = int(size)
+        self.size = size
 
     def get_city(self):
         city = City()

--- a/terminus/builders/procedural_city_builder.py
+++ b/terminus/builders/procedural_city_builder.py
@@ -16,39 +16,53 @@ from procedural_city.polygons_to_blocks_converter \
 
 import pickle
 
+import os
+import sys
+import subprocess
+
+import logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
 
 class ProceduralCityBuilder(object):
-    def __init__(self, verticesFilename, polygonsFilename):
+    def __init__(self, verticesFilename=None, polygonsFilename=None, size=1500):
         self.verticesFilename = verticesFilename
         self.polygonsFilename = polygonsFilename
+        self.ratio = 100  # ratio between pcg and gazebo (1unit = 100m)
+        self.size = int(size)
 
     def get_city(self):
         city = City()
-        ratio = 100
+
+        # If no verticesFilename or polygonsFilename is specified,
+        # generate new ones using procedural_city_generation
+        if self.verticesFilename is None or self.polygonsFilename is None:
+            self._generate_procedural_city()
 
         vertices = self._parse_vertices_file()
-        for road in self._build_roads(vertices, ratio):
+        for road in self._build_roads(vertices):
             city.add_road(road)
 
         polygons = self._parse_polygons_file()
-        for block in self._build_blocks(polygons, ratio):
+        for block in self._build_blocks(polygons):
             city.add_block(block)
 
         city.set_ground_plane(GroundPlane(100, Point(0, 0, 0)))
         return city
 
-    def _build_roads(self, vertex_list, ratio):
+    def _build_roads(self, vertex_list):
         # Convert them to Gazebo coordinates. This is definitely ugly, as
         # we are changing the type in vertex.coords, we should revisit.
         for vertex in vertex_list:
-            vertex.coords = Point(vertex.coords[0]*ratio,
-                                  vertex.coords[1]*ratio,
+            vertex.coords = Point(vertex.coords[0]*self.ratio,
+                                  vertex.coords[1]*self.ratio,
                                   0)
         # 0.79 rad ~ 45 deg
         converter = VertexGraphToRoadsConverter(0.79, vertex_list)
         return converter.get_roads()
 
-    def _build_blocks(self, polygon_list, ratio):
+    def _build_blocks(self, polygon_list):
         lot_polygons = filter(lambda polygon: polygon.is_lot(), polygon_list)
         block_polygons = []
         # Make sure the polygons overlap, as sometimes merging two polygons
@@ -56,10 +70,10 @@ class ProceduralCityBuilder(object):
         # make a small buffer (e.g. 0.1) for merging purposes and then do the
         # final buffering to tweak overlapping with the street before building
         # the block.
-        buffer_size = ratio * 0.06
+        buffer_size = self.ratio * 0.06
 
         for polygon in lot_polygons:
-            points = polygon.get_vertices_as_points(ratio)
+            points = polygon.get_vertices_as_points(self.ratio)
             poly = Polygon(points).buffer(buffer_size, 16, 1, 1, 2)
             block_polygons.append(poly)
 
@@ -85,3 +99,49 @@ class ProceduralCityBuilder(object):
             # this builder.
             contents = f.read().replace(original_name, replace_name)
             return pickle.loads(contents)
+
+    def _generate_procedural_city(self):
+        ''' Generate city using the procedural_city_generation library '''
+        this_path = os.path.realpath(__file__)
+        pcg_path = os.path.join(os.path.dirname(os.path.dirname(this_path)),
+                                'procedural_city_generation')
+
+        pcg_run = 'python {0}/UI.py'.format(pcg_path)
+
+        # Configure roadmap parameters
+        command = '{0} roadmap --configure plot False '\
+                  'border_x {1} border_y {1}'.format(pcg_run,
+                                                     int(self.size/self.ratio))
+        self._pcg_run_command(command)
+
+        # Generate roadmap
+        command = '{0} roadmap run'.format(pcg_run)
+        self._pcg_run_command(command)
+
+        # Configure polygons parameters
+        command = '{0} polygons --configure plotbool False'.format(pcg_run)
+        self._pcg_run_command(command)
+
+        # Generate polygons
+        command = '{0} polygons run'.format(pcg_run)
+        self._pcg_run_command(command)
+
+        self.temp_path = os.path.join(pcg_path,
+                                      'procedural_city_generation/temp/')
+
+        self.verticesFilename = os.path.join(self.temp_path, 'mycity')
+        self.polygonsFilename = os.path.join(self.temp_path,
+                                             'mycity_polygons.txt')
+
+    def _pcg_run_command(self, command):
+
+        with open(os.devnull, "w") as f:
+            result = subprocess.call(command.split(),
+                                     stdout=f,
+                                     stderr=subprocess.STDOUT)
+
+        if result == 0:
+            logger.debug("Command '{0}' executed succesfully".format(command))
+        else:
+            logger.fatal("Command '{0}' failed to execute".format(command))
+            sys.exit(1)

--- a/terminus/run_generator.py
+++ b/terminus/run_generator.py
@@ -45,6 +45,10 @@ builder_class = getattr(sys.modules[__name__], arguments.builder)
 # as a dictionary
 builder_parameters = dict(pair.split('=', 1) for pair in arguments.parameters)
 
+# Make sure size is an integer
+if 'size' in builder_parameters:
+    builder_parameters['size'] = int(builder_parameters['size'])
+
 # Create the builder instance. Unpack the parameter dictionary to be used as
 # keyword parameters
 builder = builder_class(**builder_parameters)


### PR DESCRIPTION
This allows seamlessly integration with the procedural_city_generation library, by running the UI.py script with the appropriate parameters. It first configures the generator, disables plotting and sets the size of the city (default = 1.5 x 1.5 Km).

This won't work until both https://github.com/josauder/procedural_city_generation/pull/24 and https://github.com/josauder/procedural_city_generation/pull/25 are merged so **DON'T MERGE YET**. We will also need to update the hash for the pcg submodule once the PRs are merged.

Since there was no pip module, I had to install it as a git submodule.

Fixes #26
