### PR TITLE
Issue/#82 debugging option for svg tool

### DIFF
--- a/tools/rndf_visualizer/README.md
+++ b/tools/rndf_visualizer/README.md
@@ -45,3 +45,17 @@ Waypoints:
 
 Trunks and lanes are dark grey. Connections between entry and exit waypoints are shown in cyan. Also, the area enclosed by perimeter waypoints is light blue now. 
 
+### SVG debug modes
+
+You can use the "debug mode" to print lanes with different colors. Also, you can selectively print waypoints. These options are configured from argument list parameters like:
+
+```
+./rndf_visualizer -d -w -g [RNDF file path]
+```
+
+Where:
+
+1. -d or --debug for printing lanes with different colors. Connections keep in cyan so as to differentiate from lanes.
+2. -w or --waypoinst for turning of waypoints. In case -d is used, waypoints color are the same to the lane they belong to.
+ 
+

--- a/tools/rndf_visualizer/include/rndf_visualizer/MapLanes.h
+++ b/tools/rndf_visualizer/include/rndf_visualizer/MapLanes.h
@@ -73,7 +73,7 @@ public:
 
   //for testing purposes, outputs an image of all polygons
   void testDraw(bool with_trans = false);
-  void testDraw(bool with_trans, const ZonePerimeterList &zones, bool svg_format);
+  void testDraw(bool with_trans, const ZonePerimeterList &zones, bool svg_format, bool debug_mode, bool waypoints_off);
   void UpdateWithCurrent(int i);
 
   void UpdatePoly(polyUpdate upPoly, float rX, float rY, float rOri);

--- a/tools/rndf_visualizer/src/MapLanes.cc
+++ b/tools/rndf_visualizer/src/MapLanes.cc
@@ -1180,39 +1180,44 @@ void drawWaypoint(svg::Document &doc, float ratio, float min_x, float max_y, flo
 	static svg::Fill yellowFill =  svg::Fill(svg::Color::Yellow);
 	static svg::Fill flatFill = svg::Fill(svg::Color::Black);
 
+	double x = (w1.map.x - min_x) * ratio;
+	double y =  (max_y - w1.map.y) * ratio;
+	double radius = 5 * ratio;
+	angle = -1.0 * angle;
+
 	if(flat) {
 		if (w1.is_stop || w1.is_perimeter || w1.checkpoint_id != 0) {
-			doc.operator << (svg::Circle(svg::Point((w1.map.x - min_x) * ratio, (max_y - w1.map.y) * ratio ), 5 * ratio, *defaultColor));
+			doc.operator << (svg::Circle(svg::Point(x, y), radius, *defaultColor));
 		}
 		else {
 			svg::Polygon arrow = svg::Polygon(*defaultColor);
-			createArrow(arrow, (w1.map.x - min_x) * ratio, (max_y - w1.map.y) * ratio , 5 * ratio, -1.0*angle);
+			createArrow(arrow, x, y , radius, angle);
 			doc.operator << (arrow);
 		}
 	}
 	else {
 		if (w1.is_exit) {
 			svg::Polygon arrow = svg::Polygon(redFill);
-			createArrow(arrow, (w1.map.x - min_x) * ratio, (max_y - w1.map.y) * ratio , 5 * ratio, -1.0*angle);
+			createArrow(arrow, x, y , radius, angle);
 			doc.operator << (arrow);		
 		}
 		else if (w1.is_entry) {
 			svg::Polygon arrow = svg::Polygon(blueFill);
-			createArrow(arrow, (w1.map.x - min_x) * ratio, (max_y - w1.map.y) * ratio , 5 * ratio, -1.0*angle);
+			createArrow(arrow, x, y , radius, angle);
 			doc.operator << (arrow);	
 		}
 		else if (w1.is_stop) {
-			doc.operator << (svg::Circle(svg::Point((w1.map.x - min_x) * ratio, (max_y - w1.map.y) * ratio ), 5 * ratio, orangeFill));
+			doc.operator << (svg::Circle(svg::Point(x, y), radius, orangeFill));
 		}
 		else if (w1.is_perimeter) {
-			doc.operator << (svg::Circle(svg::Point((w1.map.x - min_x) * ratio, (max_y - w1.map.y) * ratio ), 5 * ratio, yellowFill));
+			doc.operator << (svg::Circle(svg::Point(x, y), radius, yellowFill));
 		}
 		else if (w1.checkpoint_id != 0) {
-			doc.operator << (svg::Circle(svg::Point((w1.map.x - min_x) * ratio, (max_y - w1.map.y) * ratio ), 5 * ratio, fuchsiaFill));
+			doc.operator << (svg::Circle(svg::Point(x, y), radius, fuchsiaFill));
 		}
 		else {
 			svg::Polygon arrow = svg::Polygon(greenFill);
-			createArrow(arrow, (w1.map.x - min_x) * ratio, (max_y - w1.map.y) * ratio , 5 * ratio, -1.0*angle);
+			createArrow(arrow, x, y , radius, angle);
 			doc.operator << (arrow);
 		}		
 	}

--- a/tools/rndf_visualizer/src/MapLanes.cc
+++ b/tools/rndf_visualizer/src/MapLanes.cc
@@ -976,15 +976,23 @@ void MapLanes::testDraw(bool with_trans, const ZonePerimeterList &zones, bool sv
 	svg::Color cyanColor = svg::Color(svg::Color::Cyan);
 	svg::Color darkGrayColor = svg::Color(64, 64, 64);
 
-	svg::Color colors[] = {svg::Color::Blue,
-		svg::Color::Red, 
-		svg::Color::Green,
-		svg::Color::Fuchsia,
-		svg::Color::Orange,
-		svg::Color::Yellow,
-		svg::Color::Brown,
-		svg::Color::Purple};
-	uint colorCounter = 8;
+	svg::Color colors[] = {
+        svg::Color::Black,
+        svg::Color::Blue,
+        svg::Color::Brown,
+        svg::Color::Fuchsia,
+        svg::Color::Green,
+        svg::Color::Lime,
+        svg::Color::Magenta,
+        svg::Color::Orange,
+        svg::Color::Purple,
+        svg::Color::Red,
+        svg::Color::White,
+		svg::Color(0, 153, 115),
+        svg::Color(204, 102, 153),
+        svg::Color(51, 166, 204),
+    	svg::Color(204, 153, 0)};
+	uint colorCounter = sizeof(colors) / sizeof(colors[0]);
 
 	//draw polygons
 	for (int i = 0; i < (int)filtPolys.size(); i++)
@@ -1173,23 +1181,7 @@ void drawWaypoint(svg::Document &doc, float ratio, float min_x, float max_y, flo
 	static svg::Fill flatFill = svg::Fill(svg::Color::Black);
 
 	if(flat) {
-		if (w1.is_exit) {
-			svg::Polygon arrow = svg::Polygon(*defaultColor);
-			createArrow(arrow, (w1.map.x - min_x) * ratio, (max_y - w1.map.y) * ratio , 5 * ratio, -1.0*angle);
-			doc.operator << (arrow);		
-		}
-		else if (w1.is_entry) {
-			svg::Polygon arrow = svg::Polygon(*defaultColor);
-			createArrow(arrow, (w1.map.x - min_x) * ratio, (max_y - w1.map.y) * ratio , 5 * ratio, -1.0*angle);
-			doc.operator << (arrow);	
-		}
-		else if (w1.is_stop) {
-			doc.operator << (svg::Circle(svg::Point((w1.map.x - min_x) * ratio, (max_y - w1.map.y) * ratio ), 5 * ratio, *defaultColor));
-		}
-		else if (w1.is_perimeter) {
-			doc.operator << (svg::Circle(svg::Point((w1.map.x - min_x) * ratio, (max_y - w1.map.y) * ratio ), 5 * ratio, *defaultColor));
-		}
-		else if (w1.checkpoint_id != 0) {
+		if (w1.is_stop || w1.is_perimeter || w1.checkpoint_id != 0) {
 			doc.operator << (svg::Circle(svg::Point((w1.map.x - min_x) * ratio, (max_y - w1.map.y) * ratio ), 5 * ratio, *defaultColor));
 		}
 		else {

--- a/tools/rndf_visualizer/src/MapLanes.cc
+++ b/tools/rndf_visualizer/src/MapLanes.cc
@@ -31,7 +31,8 @@ void createArrow(svg::Polygon &triangle, float x, float y, float radius, float a
 float rotateX2DPoint(float x, float y, float angle);
 float rotateY2DPoint(float x, float y, float angle);	
 void printWayPoint(WayPointNode &wp, float angle);
-void drawWaypoint(svg::Document &doc, float ratio, float min_x, float max_y, float angle, WayPointNode &w1, bool flat);
+//void drawWaypoint(svg::Document &doc, float ratio, float min_x, float max_y, float angle, WayPointNode &w1, bool flat);
+void drawWaypoint(svg::Document &doc, float ratio, float min_x, float max_y, float angle, WayPointNode &w1, bool flat, svg::Fill *defaultColor);
 void drawLane(svg::Document &doc, std::vector<WayPointNode> &waypoints, svg::Color &color, float min_x, float max_y, float ratio);
 // intial_latlong specifies whether rndf waypoints and initial
 // coordinates are specified in lat/long or map_XY. The boolean
@@ -881,11 +882,11 @@ void MapLanes::UpdateWithCurrent(int i){
 void MapLanes::testDraw(bool with_trans)
 {
   ZonePerimeterList empty_zones;
-  MapLanes::testDraw(with_trans, empty_zones, false);
+  MapLanes::testDraw(with_trans, empty_zones, false, false, false);
 }
 
 //test function which outputs all polygons to a pgm image.
-void MapLanes::testDraw(bool with_trans, const ZonePerimeterList &zones, bool svg_format)
+void MapLanes::testDraw(bool with_trans, const ZonePerimeterList &zones, bool svg_format, bool debug_mode, bool waypoints_off)
 {
   float max_x = -FLT_MAX;
   float min_x = FLT_MAX;
@@ -1030,17 +1031,29 @@ void MapLanes::testDraw(bool with_trans, const ZonePerimeterList &zones, bool sv
 		getWaypointsByLanes(laneList, graph->nodes, graph->nodes_size);
 		for(uint i = 0, colorIndex = 0; i < laneList.size(); i++, colorIndex++, colorIndex %= colorCounter){
 			std::vector<WayPointNode> laneNodes = laneList.at(i);
-
-			drawLane(doc, laneNodes, colors[colorIndex], min_x, max_y, ratio);
-
-			std::vector<float> waypointThetas;
-			//Get the deviation of each waypoint so as to get the theta
-			getWaypointsTheta(laneNodes, waypointThetas);
-			//Draw each waypoint with its deviation
-			for(uint j = 0; j < laneNodes.size(); j++){
-				WayPointNode w1 = laneNodes.at(j);
-				float angle = waypointThetas.at(j);
-				drawWaypoint(doc, ratio, min_x, max_y, angle, w1, true);
+			if(debug_mode == true) {
+				drawLane(doc, laneNodes, colors[colorIndex], min_x, max_y, ratio);
+			}
+			else {
+				drawLane(doc, laneNodes, darkGrayColor, min_x, max_y, ratio);
+			}
+			if(waypoints_off == false) {
+				std::vector<float> waypointThetas;
+				//Get the deviation of each waypoint so as to get the theta
+				getWaypointsTheta(laneNodes, waypointThetas);
+				//Draw each waypoint with its deviation
+				for(uint j = 0; j < laneNodes.size(); j++) {
+					WayPointNode w1 = laneNodes.at(j);
+					float angle = waypointThetas.at(j);
+					if(debug_mode == true) {
+						svg::Fill fill(colors[colorIndex]);
+						drawWaypoint(doc, ratio, min_x, max_y, angle, w1, true, &fill);
+					}
+					else {
+						drawWaypoint(doc, ratio, min_x, max_y, angle, w1, false, NULL);
+					}
+					
+				}
 			}
 		}
 	}
@@ -1149,7 +1162,7 @@ void createEquilateralTriangle(svg::Polygon &triangle, float x, float y, float r
 }
 
 
-void drawWaypoint(svg::Document &doc, float ratio, float min_x, float max_y, float angle, WayPointNode &w1, bool flat){
+void drawWaypoint(svg::Document &doc, float ratio, float min_x, float max_y, float angle, WayPointNode &w1, bool flat, svg::Fill *defaultColor){
 	static svg::Fill greenFill = svg::Fill(svg::Color::Green);
 	static svg::Fill redFill = svg::Fill(svg::Color::Red);
 	static svg::Fill blueFill = svg::Fill(svg::Color::Blue);
@@ -1161,26 +1174,26 @@ void drawWaypoint(svg::Document &doc, float ratio, float min_x, float max_y, flo
 
 	if(flat) {
 		if (w1.is_exit) {
-			svg::Polygon arrow = svg::Polygon(flatFill);
+			svg::Polygon arrow = svg::Polygon(*defaultColor);
 			createArrow(arrow, (w1.map.x - min_x) * ratio, (max_y - w1.map.y) * ratio , 5 * ratio, -1.0*angle);
 			doc.operator << (arrow);		
 		}
 		else if (w1.is_entry) {
-			svg::Polygon arrow = svg::Polygon(flatFill);
+			svg::Polygon arrow = svg::Polygon(*defaultColor);
 			createArrow(arrow, (w1.map.x - min_x) * ratio, (max_y - w1.map.y) * ratio , 5 * ratio, -1.0*angle);
 			doc.operator << (arrow);	
 		}
 		else if (w1.is_stop) {
-			doc.operator << (svg::Circle(svg::Point((w1.map.x - min_x) * ratio, (max_y - w1.map.y) * ratio ), 5 * ratio, flatFill));
+			doc.operator << (svg::Circle(svg::Point((w1.map.x - min_x) * ratio, (max_y - w1.map.y) * ratio ), 5 * ratio, *defaultColor));
 		}
 		else if (w1.is_perimeter) {
-			doc.operator << (svg::Circle(svg::Point((w1.map.x - min_x) * ratio, (max_y - w1.map.y) * ratio ), 5 * ratio, flatFill));
+			doc.operator << (svg::Circle(svg::Point((w1.map.x - min_x) * ratio, (max_y - w1.map.y) * ratio ), 5 * ratio, *defaultColor));
 		}
 		else if (w1.checkpoint_id != 0) {
-			doc.operator << (svg::Circle(svg::Point((w1.map.x - min_x) * ratio, (max_y - w1.map.y) * ratio ), 5 * ratio, flatFill));
+			doc.operator << (svg::Circle(svg::Point((w1.map.x - min_x) * ratio, (max_y - w1.map.y) * ratio ), 5 * ratio, *defaultColor));
 		}
 		else {
-			svg::Polygon arrow = svg::Polygon(flatFill);
+			svg::Polygon arrow = svg::Polygon(*defaultColor);
 			createArrow(arrow, (w1.map.x - min_x) * ratio, (max_y - w1.map.y) * ratio , 5 * ratio, -1.0*angle);
 			doc.operator << (arrow);
 		}

--- a/tools/rndf_visualizer/src/MapLanes.cc
+++ b/tools/rndf_visualizer/src/MapLanes.cc
@@ -988,10 +988,10 @@ void MapLanes::testDraw(bool with_trans, const ZonePerimeterList &zones, bool sv
         svg::Color::Purple,
         svg::Color::Red,
         svg::Color::White,
-		svg::Color(0, 153, 115),
+        svg::Color(0, 153, 115),
         svg::Color(204, 102, 153),
         svg::Color(51, 166, 204),
-    	svg::Color(204, 153, 0)};
+        svg::Color(204, 153, 0)};
 	uint colorCounter = sizeof(colors) / sizeof(colors[0]);
 
 	//draw polygons

--- a/tools/rndf_visualizer/src/rndf_visualizer.cc
+++ b/tools/rndf_visualizer/src/rndf_visualizer.cc
@@ -39,6 +39,8 @@ bool print_polys = false;
 bool output_polys = false;
 bool make_image = false;
 bool svg_format = false;
+bool debug_mode = false;
+bool waypoints_off = false;
 bool with_trans = false;
 int verbose = 0;
 char *rndf_name;
@@ -163,7 +165,7 @@ bool build_RNDF()
 void parse_args(int argc, char *argv[])
 {
   bool print_usage = false;
-  const char *options = "higops:tx:y:v";
+  const char *options = "higops:tx:y:vdw";
   int opt = 0;
   int option_index = 0;
   struct option long_options[] =
@@ -171,6 +173,8 @@ void parse_args(int argc, char *argv[])
       { "help", 0, 0, 'h' },
       { "image", 0, 0, 'i' },
       { "svg", 0, 0, 'g' },
+      { "debug", 0, 0, 'd' },
+      { "waypoints", 0, 0, 'w' },
       { "latitude", 1, 0, 'x' },
       { "longitude", 1, 0, 'y' },
       { "size", 1, 0, 's' },
@@ -198,9 +202,18 @@ void parse_args(int argc, char *argv[])
 	  make_image = true;
 	  break;
 
+    case 'd':
+      debug_mode = true;
+      break;
+
+    case 'w':
+      waypoints_off = true;
+      break;
+
 	case 'g':
 	  make_image = true;
-    svg_format = true;
+	  svg_format = true;
+	  break;
 
 	case 'v':
 	  ++verbose;
@@ -242,7 +255,9 @@ void parse_args(int argc, char *argv[])
 	      "\t-y, --latitude\tinitial pose latitude\n"
 	      "\t-x, --longitude\tinitial pose longitude\n"
 	      "\t-s, --size\tmax polygon size\n"
-	      "\t-v, --verbose\tprint verbose messages\n",
+	      "\t-v, --verbose\tprint verbose messages\n"
+	      "\t-d, --debug\tprint lanes in different colors and waypoints in black\n"
+	      "\t-w, --waypoints\tturn off waypoint creation\n",
 	      pname);
       exit(9);
     }
@@ -273,7 +288,7 @@ int main(int argc, char *argv[]) {
   if (make_image) {
     ZonePerimeterList zones = ZoneOps::build_zone_list_from_rndf(*rndf, *graph);
     mapl-> SetGPS(centerx,centery);
-	  mapl-> testDraw(with_trans, zones, svg_format);
+	mapl-> testDraw(with_trans, zones, svg_format, debug_mode, waypoints_off);
   }
   return rc;
 }


### PR DESCRIPTION
This feature includes a new way of creating SVG files configured from the argument list. Usage is:

- '-d' or '--debug' for printing lanes with diffferent colors.
- '-w' or '--waypoints' for not printing waypoints.

This should be used with '-g' option. 

Results are the following:

- Big city (10Kmsq)
![sample1bigcity](https://cloud.githubusercontent.com/assets/3825465/20711415/552f7e86-b61e-11e6-91a6-d4d00843a1e9.png)


![sample2bigcity](https://cloud.githubusercontent.com/assets/3825465/20711406/4ec3610c-b61e-11e6-8878-88f67801dee2.png)

- Darpa sample

![svgdebug1](https://cloud.githubusercontent.com/assets/3825465/20711445/77db2fb6-b61e-11e6-85c1-5a42998188d4.png)

![debugsvg2](https://cloud.githubusercontent.com/assets/3825465/20711452/82ae2966-b61e-11e6-85c9-e3f328b9773b.png)

