### PR TITLE
Don't compile Gazebo tests in Docker

### DIFF
--- a/docker/gazebo-terminus/Dockerfile
+++ b/docker/gazebo-terminus/Dockerfile
@@ -59,7 +59,7 @@ RUN cd /home/gazebo/ws/sdformat; mkdir build; cd build; cmake .. -DCMAKE_INSTALL
 # Download and compile Gazebo
 RUN hg clone https://bitbucket.org/osrf/gazebo /home/gazebo/ws/gazebo
 # Use branch visualization on demand
-RUN cd /home/gazebo/ws/gazebo; hg up -r ${gazebo_commit}; mkdir build; cd build; cmake .. -DCMAKE_INSTALL_PREFIX=/usr; make -j4; make install
+RUN cd /home/gazebo/ws/gazebo; hg up -r ${gazebo_commit}; mkdir build; cd build; cmake -DCMAKE_INSTALL_PREFIX=/usr -DENABLE_TESTS_COMPILATION=FALSE ../; make -j4; make install
 
 RUN mkdir -p /home/gazebo/ws/src
 


### PR DESCRIPTION
This is done so compilation of gazebo is done under one hour. If not the automatic build of the docker container in docker hub fails because it exceeds the two hours time limit.