### PR TITLE
Fixes issues with flipped maps

### DIFF
--- a/terminus/builders/osm_city_builder.py
+++ b/terminus/builders/osm_city_builder.py
@@ -171,7 +171,7 @@ class OsmCityBuilder(object):
 
     def _translate_coords(self, lat, lon):
         meters_per_degree_lat = 111319.9
-        meters_per_degree_lon = meters_per_degree_lat * math.cos(self.map_origin.x)
+        meters_per_degree_lon = meters_per_degree_lat * math.cos(math.radians(self.map_origin.x))
         x = (lon - self.map_origin.y) * meters_per_degree_lon
         y = (lat - self.map_origin.x) * meters_per_degree_lat
         return Point(x, y, 0)

--- a/terminus/generators/rndf_generator.py
+++ b/terminus/generators/rndf_generator.py
@@ -49,7 +49,7 @@ class RNDFGenerator(FileGenerator):
     def translate_waypoint(self, waypoint):
         center = waypoint.center
         meters_per_degree_lat = 111319.9
-        meters_per_degree_lon = meters_per_degree_lat * math.cos(self.origin.x)
+        meters_per_degree_lon = meters_per_degree_lat * math.cos(math.radians(self.origin.x))
         lat = self.origin.x + (center.y / meters_per_degree_lat)
         lon = self.origin.y - (center.x / meters_per_degree_lon)
         return (lat, lon)

--- a/terminus/tests/rndf_generator_test.py
+++ b/terminus/tests/rndf_generator_test.py
@@ -60,8 +60,8 @@ class RNDFGeneratorTest(unittest.TestCase):
         num_waypoints\t3
         lane_width\t5
         1.1.1\t45.000000\t65.000000
-        1.1.2\t45.000000\t64.982900
-        1.1.3\t45.000000\t64.965800
+        1.1.2\t45.000000\t64.987296
+        1.1.3\t45.000000\t64.974592
         end_lane
         end_segment
         end_file""")
@@ -105,10 +105,10 @@ class RNDFGeneratorTest(unittest.TestCase):
         num_waypoints\t4
         lane_width\t5
         exit\t1.1.2\t2.1.3
-        1.1.1\t45.000000\t65.017100
-        1.1.2\t45.000000\t65.000086
-        1.1.3\t45.000000\t64.999914
-        1.1.4\t45.000000\t64.982900
+        1.1.1\t45.000000\t65.012704
+        1.1.2\t45.000000\t65.000064
+        1.1.3\t45.000000\t64.999936
+        1.1.4\t45.000000\t64.987296
         end_lane
         end_segment
         segment\t2
@@ -168,8 +168,8 @@ class RNDFGeneratorTest(unittest.TestCase):
         num_waypoints\t3
         lane_width\t5
         2.1.1\t45.000000\t65.000000
-        2.1.2\t45.000000\t64.999914
-        2.1.3\t45.000000\t64.982900
+        2.1.2\t45.000000\t64.999936
+        2.1.3\t45.000000\t64.987296
         end_lane
         end_segment
         end_file""")
@@ -223,8 +223,8 @@ class RNDFGeneratorTest(unittest.TestCase):
         num_waypoints\t3
         lane_width\t5
         2.1.1\t45.000000\t65.000000
-        2.1.2\t44.999968\t65.000060
-        2.1.3\t44.991017\t65.017100
+        2.1.2\t44.999968\t65.000045
+        2.1.3\t44.991017\t65.012704
         end_lane
         end_segment
         segment\t3
@@ -234,8 +234,8 @@ class RNDFGeneratorTest(unittest.TestCase):
         num_waypoints\t3
         lane_width\t5
         3.1.1\t45.000000\t65.000000
-        3.1.2\t44.999968\t64.999940
-        3.1.3\t44.991017\t64.982900
+        3.1.2\t44.999968\t64.999955
+        3.1.3\t44.991017\t64.987296
         end_lane
         end_segment
         end_file""")
@@ -287,8 +287,8 @@ class RNDFGeneratorTest(unittest.TestCase):
         num_waypoints\t3
         lane_width\t5
         exit\t2.1.2\t1.1.2
-        2.1.1\t44.991017\t65.017100
-        2.1.2\t44.999968\t65.000060
+        2.1.1\t44.991017\t65.012704
+        2.1.2\t44.999968\t65.000045
         2.1.3\t45.000000\t65.000000
         end_lane
         end_segment
@@ -299,8 +299,8 @@ class RNDFGeneratorTest(unittest.TestCase):
         num_waypoints\t3
         lane_width\t5
         exit\t3.1.2\t1.1.2
-        3.1.1\t44.991017\t64.982900
-        3.1.2\t44.999968\t64.999940
+        3.1.1\t44.991017\t64.987296
+        3.1.2\t44.999968\t64.999955
         3.1.3\t45.000000\t65.000000
         end_lane
         end_segment


### PR DESCRIPTION
This was because we were using degrees instead of radians for the conversions. Fixes #119 