### PR TITLE
Fix longitude conversion formula

### DIFF
--- a/terminus/builders/osm_city_builder.py
+++ b/terminus/builders/osm_city_builder.py
@@ -172,6 +172,6 @@ class OsmCityBuilder(object):
     def _translate_coords(self, lat, lon):
         meters_per_degree_lat = 111319.9
         meters_per_degree_lon = meters_per_degree_lat * math.cos(math.radians(self.map_origin.x))
-        x = (lon - self.map_origin.y) * meters_per_degree_lon
+        x = (self.map_origin.y - lon) * meters_per_degree_lon
         y = (lat - self.map_origin.x) * meters_per_degree_lat
         return Point(x, y, 0)


### PR DESCRIPTION
Sorry about this, when we were using angles instead of radians, I had to modify this formula to make it work. Reverting to the "correct" way of doing it (based on the code on the rndf_generator). I've tested with a few maps and everything seems to be working OK