### PR TITLE
Issue/#128 include dockerfiles to start from cloud image

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -21,3 +21,10 @@ gazebo-terminus-nvidia: gazebo-terminus
 gazebo-terminus-intel: gazebo-terminus
 	docker build ${DOCKER_ARGS} -t gazebo-terminus-intel gazebo-terminus-intel
 
+.PHONY: ekumenlabs-terminus-intel
+ekumenlabs-terminus-intel:
+	docker build ${DOCKER_ARGS} -t ekumenlabs-terminus-intel ekumenlabs-terminus-intel
+
+.PHONY: ekumenlabs-terminus-nvidia
+ekumenlabs-terminus-intel:
+	docker build ${DOCKER_ARGS} -t ekumenlabs-terminus-nvidia ekumenlabs-terminus-nvidia

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -26,5 +26,5 @@ ekumenlabs-terminus-intel:
 	docker build ${DOCKER_ARGS} -t ekumenlabs-terminus-intel ekumenlabs-terminus-intel
 
 .PHONY: ekumenlabs-terminus-nvidia
-ekumenlabs-terminus-intel:
+ekumenlabs-terminus-nvidia:
 	docker build ${DOCKER_ARGS} -t ekumenlabs-terminus-nvidia ekumenlabs-terminus-nvidia

--- a/docker/README.md
+++ b/docker/README.md
@@ -11,16 +11,20 @@ cd {REPOSITORY_PATH}/terminus/docker
 $ ./run_simulator [CONTAINER_NAME] [CONTAINER_IMAGE]
 ```
 
-The image name is the one that you use with the makefile, for now:
+The image name is the one that you use with the Makefile, for now:
 
-* gazebo-terminus-nvidia
-* gazebo-terminus-intel
+* gazebo-terminus-nvidia      --> compiles everything from source 
+* gazebo-terminus-intel       --> compiles everything from source
+* ekumenlabs-terminus-intel   --> only compiles the drivers, the rest is downloaded
+* ekumenlabs-terminus-nvidia  --> only compiles the drivers, the rest is downloaded
 
 We recommend to use the same name for the container, so you should run one of these commands:
 
 ```
 $ ./run_simulator gazebo-terminus-nvidia gazebo-terminus-nvidia
 $ ./run_simulator gazebo-terminus-intel gazebo-terminus-intel
+$ ./run_simulator ekumenlabs-terminus-nvidia ekumenlabs-terminus-nvidia
+$ ./run_simulator ekumenlabs-terminus-intel ekumenlabs-terminus-intel
 ```
 
 The script `run_simulator` is configured to mount 2 directories:

--- a/docker/ekumenlabs-terminus-intel/Dockerfile
+++ b/docker/ekumenlabs-terminus-intel/Dockerfile
@@ -1,0 +1,14 @@
+FROM ekumenlabs/gazebo-terminus
+
+MAINTAINER Javier Choclin, jchoclin@ekumenlabs.com
+
+USER root
+
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+
+# Keeps some debs from trying to open dialogs during installation
+ENV DEBIAN_FRONTEND noninteractive
+
+# Install the NVIDIA binary drivers
+RUN apt-get install -y libgl1-mesa-glx libgl1-mesa-dri xserver-xorg-video-intel

--- a/docker/ekumenlabs-terminus-intel/Dockerfile
+++ b/docker/ekumenlabs-terminus-intel/Dockerfile
@@ -11,4 +11,4 @@ ENV LANG en_US.UTF-8
 ENV DEBIAN_FRONTEND noninteractive
 
 # Install the NVIDIA binary drivers
-RUN apt-get install -y libgl1-mesa-glx libgl1-mesa-dri xserver-xorg-video-intel
+RUN apt-get update && apt-get install -y libgl1-mesa-glx libgl1-mesa-dri xserver-xorg-video-intel

--- a/docker/ekumenlabs-terminus-nvidia/Dockerfile
+++ b/docker/ekumenlabs-terminus-nvidia/Dockerfile
@@ -1,0 +1,18 @@
+FROM ekumenlabs/gazebo-terminus
+
+MAINTAINER Javier Choclin, jchoclin@ekumenlabs.com
+
+ARG nvidia_driver
+
+USER root
+
+# Keeps some debs from trying to open dialogs during installation
+ENV DEBIAN_FRONTEND noninteractive
+
+# Install the NVIDIA binary drivers
+USER root
+RUN apt-get -y install software-properties-common # for add-apt-repository
+RUN add-apt-repository ppa:graphics-drivers/ppa
+RUN apt-get update
+RUN apt-get install -y mesa-utils
+RUN apt-get install -y $nvidia_driver


### PR DESCRIPTION
Now there are two new commands:

- ekumenlabs-terminus-intel
- ekumenlabs-terminus-nvidia

These two use the ekumenlabs/gazebo-terminus image instead of compiling it from source to save time. Readme has been updated.

@Shokman in another issue I'll split the dockerfiles. 