### PR TITLE
Organize generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ Some examples:
     ```
     $ python terminus/run_generator.py --builder=SimpleCityBuilder --destination=demo_city.world
     ```
+    * Use the debug flag to generate additional files for debugging purposes
+    ```
+    $ python terminus/run_generator.py --builder=SimpleCityBuilder --debug
+    ```
     * Generate the city using the `procedural_city_generation` package:
     ```
     $ python terminus/run_generator.py --builder=ProceduralCityBuilder --parameters size=1500

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ $ ln -s ../../pre-commit.sh .git/hooks/pre-commit
 
 ## Run generators
 
-- Execute `$ python terminus/run_generator.py` to create a new city. In order for the generator to run you **must** specify the builder to use (and its required constructor values). You can optionally specify the output file (if none specified the output will be written to `generated_worlds/city.world`).
+- Execute `$ python terminus/run_generator.py` to create a new city. In order for the generator to run you **must** specify the builder to use (and its required constructor values). You can optionally specify the output files name (if none specified the output will be written to `generated_worlds/city.*`).
 Some examples:
 
     * Get help:
@@ -98,7 +98,7 @@ Some examples:
     ```
     * Specify the output file:
     ```
-    $ python terminus/run_generator.py --builder=SimpleCityBuilder --destination=demo_city.world
+    $ python terminus/run_generator.py --builder=SimpleCityBuilder --destination=demo_city
     ```
     * Use the debug flag to generate additional files for debugging purposes
     ```

--- a/terminus/generators/abstract_sdf_generator.py
+++ b/terminus/generators/abstract_sdf_generator.py
@@ -1,0 +1,183 @@
+from file_generator import FileGenerator
+
+
+class AbstractSDFGenerator(FileGenerator):
+
+    def end_document(self):
+        self._wrap_document_with_template('document')
+
+    def end_city(self, city):
+        self._wrap_document_with_contents_for(city)
+
+    def end_block(self, block):
+        self._append_to_document(self._contents_for(block))
+
+    def end_building(self, building):
+        self._append_to_document(self._contents_for(building))
+
+    def end_ground_plane(self, ground_plane):
+        self._append_to_document(self._contents_for(ground_plane))
+
+    def city_template(self):
+        return """
+        <world name="{{model.name}}">
+        <gui fullscreen='0'>
+          <camera name='city_camera'>
+            <pose frame=''>
+              -0.065965 0.276379 1005.72 2e-06 1.5538 1.5962
+            </pose>
+          </camera>
+        </gui>
+        <include>
+          <uri>model://sun</uri>
+        </include>
+          {{inner_contents}}
+        </world>
+        """
+
+    def block_template(self):
+        return """
+        <model name="{{model.name}}">
+          <static>1</static>
+          <allow_auto_disable>1</allow_auto_disable>
+          <link name="{{model.name}}_link">
+            <pose frame="">
+              {{model.origin.x}} {{model.origin.y}} {{model.origin.z}}
+              0 0 0
+            </pose>
+            <collision name="{{model.name}}_collision">
+              <geometry>
+                <polyline>
+                {% for vertex in model.vertices %}
+                  <point>{{vertex.x}} {{vertex.y}}</point>
+                {% endfor %}
+                <height>{{model.height}}</height>
+                </polyline>
+              </geometry>
+            </collision>
+            <visual name="{{model.name}}_visual">
+              <material>
+                <script>
+                  <uri>
+                    file://media/materials/scripts/gazebo.material
+                  </uri>
+                  <name>Gazebo/Grey</name>
+                </script>
+                <ambient>1 1 1 1</ambient>
+              </material>
+              <meta>
+                <layer>0</layer>
+              </meta>
+              <geometry>
+                <polyline>
+                {% for vertex in model.vertices %}
+                  <point>{{vertex.x}} {{vertex.y}}</point>
+                {% endfor %}
+                <height>{{model.height}}</height>
+                </polyline>
+              </geometry>
+            </visual>
+          </link>
+        </model>"""
+
+    def building_template(self):
+        return """
+          <model name="{{model.name}}">
+             <static>1</static>
+             <link name="{{model.name}}_link">
+                <pose frame="">
+                  {{model.origin.x}} {{model.origin.y}} {{model.origin.z}}
+                  0 0 0
+                </pose>
+                <collision name="{{model.name}}_collision">
+                   <geometry>
+                        <polyline>
+                        {% for vertex in model.vertices %}
+                          <point>{{vertex.x}} {{vertex.y}}</point>
+                        {% endfor %}
+                        <height>{{model.height}}</height>
+                        </polyline>
+                   </geometry>
+                </collision>
+                <visual name="{{model.name}}_visual">
+                   <material>
+                      <script>
+                        <uri>
+                          file://media/materials/scripts/gazebo.material
+                        </uri>
+                        <name>Gazebo/Grey</name>
+                      </script>
+                      <ambient>1 1 1 1</ambient>
+                   </material>
+                   <meta>
+                      <layer>0</layer>
+                   </meta>
+                   <geometry>
+                        <polyline>
+                        {% for vertex in model.vertices %}
+                          <point>{{vertex.x}} {{vertex.y}}</point>
+                        {% endfor %}
+                        <height>{{model.height}}</height>
+                        </polyline>
+                   </geometry>
+                </visual>
+             </link>
+          </model>"""
+
+    def ground_plane_template(self):
+        return """
+          <model name="{{model.name}}">
+            <static>1</static>
+            <pose frame=''>{{model.origin.x}} {{model.origin.y}} 0 0 0 0</pose>
+            <link name='{{model.name}}_link'>
+              <collision name='{{model.name}}'>
+                <geometry>
+                  <plane>
+                    <normal>0 0 1</normal>
+                    <size>{{model.size}} {{model.size}}</size>
+                  </plane>
+                </geometry>
+                <surface>
+                  <friction>
+                    <ode>
+                      <mu>100</mu>
+                      <mu2>50</mu2>
+                    </ode>
+                    <torsional>
+                      <ode/>
+                    </torsional>
+                  </friction>
+                  <contact>
+                    <ode/>
+                  </contact>
+                  <bounce/>
+                </surface>
+                <max_contacts>10</max_contacts>
+              </collision>
+              <visual name='{{model.name}}'>
+                <cast_shadows>0</cast_shadows>
+                <geometry>
+                  <plane>
+                    <normal>0 0 1</normal>
+                    <size>{{model.size}} {{model.size}}</size>
+                  </plane>
+                </geometry>
+                <material>
+                  <script>
+                    <uri>file://media/materials/scripts/gazebo.material</uri>
+                    <name>Gazebo/Grey</name>
+                  </script>
+                </material>
+                <transparency>1</transparency>
+              </visual>
+              <self_collide>0</self_collide>
+              <kinematic>0</kinematic>
+            </link>
+          </model>"""
+
+    def document_template(self):
+        return """
+        <?xml version="1.0" ?>
+        <sdf version="1.5">
+          {{inner_contents}}
+        </sdf>"""

--- a/terminus/generators/sdf_generator_gazebo_7.py
+++ b/terminus/generators/sdf_generator_gazebo_7.py
@@ -1,7 +1,10 @@
 from file_generator import FileGenerator
 
 
-class SDFGenerator(FileGenerator):
+class SDFGeneratorGazebo7(FileGenerator):
+    """This class generates an sdf file that can be loaded using a vanilla
+    Gazebo 7 install. The file is self-contained and to model streets it uses
+    the built-in <road> tag"""
 
     def end_document(self):
         self._wrap_document_with_template('document')

--- a/terminus/generators/sdf_generator_gazebo_7.py
+++ b/terminus/generators/sdf_generator_gazebo_7.py
@@ -1,47 +1,16 @@
-from file_generator import FileGenerator
+from abstract_sdf_generator import AbstractSDFGenerator
 
 
-class SDFGeneratorGazebo7(FileGenerator):
+class SDFGeneratorGazebo7(AbstractSDFGenerator):
     """This class generates an sdf file that can be loaded using a vanilla
     Gazebo 7 install. The file is self-contained and to model streets it uses
     the built-in <road> tag"""
-
-    def end_document(self):
-        self._wrap_document_with_template('document')
-
-    def end_city(self, city):
-        self._wrap_document_with_contents_for(city)
 
     def end_street(self, street):
         self._append_to_document(self._contents_for(street))
 
     def end_trunk(self, trunk):
         self._append_to_document(self._contents_for(trunk))
-
-    def end_block(self, block):
-        self._append_to_document(self._contents_for(block))
-
-    def end_building(self, building):
-        self._append_to_document(self._contents_for(building))
-
-    def end_ground_plane(self, ground_plane):
-        self._append_to_document(self._contents_for(ground_plane))
-
-    def city_template(self):
-        return """
-        <world name="{{model.name}}">
-        <gui fullscreen='0'>
-          <camera name='city_camera'>
-            <pose frame=''>
-              -0.065965 0.276379 1005.72 2e-06 1.5538 1.5962
-            </pose>
-          </camera>
-        </gui>
-        <include>
-          <uri>model://sun</uri>
-        </include>
-          {{inner_contents}}
-        </world>"""
 
     def street_template(self):
         return """
@@ -72,150 +41,3 @@ class SDFGeneratorGazebo7(FileGenerator):
           <point>{{node.center.x}} {{node.center.y}} {{node.center.z}}</point>
         {% endfor %}
         </road>"""
-
-    def block_template(self):
-        return """
-        <model name="{{model.name}}">
-          <static>1</static>
-          <allow_auto_disable>1</allow_auto_disable>
-          <link name="{{model.name}}_link">
-            <pose frame="">
-              {{model.origin.x}} {{model.origin.y}} {{model.origin.z}}
-              0 0 0
-            </pose>
-            <collision name="{{model.name}}_collision">
-              <geometry>
-                <polyline>
-                {% for vertex in model.vertices %}
-                  <point>{{vertex.x}} {{vertex.y}}</point>
-                {% endfor %}
-                <height>{{model.height}}</height>
-                </polyline>
-              </geometry>
-            </collision>
-            <visual name="{{model.name}}_visual">
-              <material>
-                <script>
-                  <uri>
-                    file://media/materials/scripts/gazebo.material
-                  </uri>
-                  <name>Gazebo/Grey</name>
-                </script>
-                <ambient>1 1 1 1</ambient>
-              </material>
-              <meta>
-                <layer>0</layer>
-              </meta>
-              <geometry>
-                <polyline>
-                {% for vertex in model.vertices %}
-                  <point>{{vertex.x}} {{vertex.y}}</point>
-                {% endfor %}
-                <height>{{model.height}}</height>
-                </polyline>
-              </geometry>
-            </visual>
-          </link>
-        </model>"""
-
-    def building_template(self):
-        return """
-          <model name="{{model.name}}">
-             <static>1</static>
-             <link name="{{model.name}}_link">
-                <pose frame="">
-                  {{model.origin.x}} {{model.origin.y}} {{model.origin.z}}
-                  0 0 0
-                </pose>
-                <collision name="{{model.name}}_collision">
-                   <geometry>
-                        <polyline>
-                        {% for vertex in model.vertices %}
-                          <point>{{vertex.x}} {{vertex.y}}</point>
-                        {% endfor %}
-                        <height>{{model.height}}</height>
-                        </polyline>
-                   </geometry>
-                </collision>
-                <visual name="{{model.name}}_visual">
-                   <material>
-                      <script>
-                        <uri>
-                          file://media/materials/scripts/gazebo.material
-                        </uri>
-                        <name>Gazebo/Grey</name>
-                      </script>
-                      <ambient>1 1 1 1</ambient>
-                   </material>
-                   <meta>
-                      <layer>0</layer>
-                   </meta>
-                   <geometry>
-                        <polyline>
-                        {% for vertex in model.vertices %}
-                          <point>{{vertex.x}} {{vertex.y}}</point>
-                        {% endfor %}
-                        <height>{{model.height}}</height>
-                        </polyline>
-                   </geometry>
-                </visual>
-             </link>
-          </model>"""
-
-    def ground_plane_template(self):
-        return """
-          <model name="{{model.name}}">
-            <static>1</static>
-            <pose frame=''>{{model.origin.x}} {{model.origin.y}} 0 0 0 0</pose>
-            <link name='{{model.name}}_link'>
-              <collision name='{{model.name}}'>
-                <geometry>
-                  <plane>
-                    <normal>0 0 1</normal>
-                    <size>{{model.size}} {{model.size}}</size>
-                  </plane>
-                </geometry>
-                <surface>
-                  <friction>
-                    <ode>
-                      <mu>100</mu>
-                      <mu2>50</mu2>
-                    </ode>
-                    <torsional>
-                      <ode/>
-                    </torsional>
-                  </friction>
-                  <contact>
-                    <ode/>
-                  </contact>
-                  <bounce/>
-                </surface>
-                <max_contacts>10</max_contacts>
-              </collision>
-              <visual name='{{model.name}}'>
-                <cast_shadows>0</cast_shadows>
-                <geometry>
-                  <plane>
-                    <normal>0 0 1</normal>
-                    <size>{{model.size}} {{model.size}}</size>
-                  </plane>
-                </geometry>
-                <material>
-                  <script>
-                    <uri>file://media/materials/scripts/gazebo.material</uri>
-                    <name>Gazebo/Grey</name>
-                  </script>
-                </material>
-                <transparency>1</transparency>
-              </visual>
-              <self_collide>0</self_collide>
-              <kinematic>0</kinematic>
-            </link>
-          </model>"""
-
-    def document_template(self):
-        return """
-        <?xml version="1.0" ?>
-        <sdf version="1.5">
-          {{inner_contents}}
-        </sdf>"""

--- a/terminus/generators/sdf_generator_gazebo_8.py
+++ b/terminus/generators/sdf_generator_gazebo_8.py
@@ -1,0 +1,197 @@
+from file_generator import FileGenerator
+
+
+class SDFGeneratorGazebo8(FileGenerator):
+    """This class generates an sdf file that loads the road network from an RNDF
+    file. In order to use this you will need Gazebo 8 and the plugin to render
+    RNDF"""
+
+    def __init__(self, city, rndf_path):
+        super(SDFGeneratorGazebo8, self).__init__(city)
+        self.rndf_path = rndf_path
+
+    def end_document(self):
+        self._wrap_document_with_template('document')
+
+    def end_city(self, city):
+        self._wrap_document_with_contents_for(city)
+
+    def end_block(self, block):
+        self._append_to_document(self._contents_for(block))
+
+    def end_building(self, building):
+        self._append_to_document(self._contents_for(building))
+
+    def end_ground_plane(self, ground_plane):
+        self._append_to_document(self._contents_for(ground_plane))
+
+    def city_template(self):
+        return """
+        <world name="{{model.name}}">
+        <gui fullscreen='0'>
+          <camera name='city_camera'>
+            <pose frame=''>
+              -0.065965 0.276379 1005.72 2e-06 1.5538 1.5962
+            </pose>
+          </camera>
+        </gui>
+        <include>
+          <uri>model://sun</uri>
+        </include>
+        <plugin name='rndf_gazebo_plugin0' filename='librndf_gazebo_plugin0.so.0.0.1'>
+          <rndf>{{generator.rndf_path}}</rndf>
+          <lanes>true</lanes>
+          <waypoints>true</waypoints>
+          <junctions>true</junctions>
+          <waypoints_material>Gazebo/White</waypoints_material>
+        </plugin>
+          {{inner_contents}}
+        </world>
+        """
+
+    def block_template(self):
+        return """
+        <model name="{{model.name}}">
+          <static>1</static>
+          <allow_auto_disable>1</allow_auto_disable>
+          <link name="{{model.name}}_link">
+            <pose frame="">
+              {{model.origin.x}} {{model.origin.y}} {{model.origin.z}}
+              0 0 0
+            </pose>
+            <collision name="{{model.name}}_collision">
+              <geometry>
+                <polyline>
+                {% for vertex in model.vertices %}
+                  <point>{{vertex.x}} {{vertex.y}}</point>
+                {% endfor %}
+                <height>{{model.height}}</height>
+                </polyline>
+              </geometry>
+            </collision>
+            <visual name="{{model.name}}_visual">
+              <material>
+                <script>
+                  <uri>
+                    file://media/materials/scripts/gazebo.material
+                  </uri>
+                  <name>Gazebo/Grey</name>
+                </script>
+                <ambient>1 1 1 1</ambient>
+              </material>
+              <meta>
+                <layer>0</layer>
+              </meta>
+              <geometry>
+                <polyline>
+                {% for vertex in model.vertices %}
+                  <point>{{vertex.x}} {{vertex.y}}</point>
+                {% endfor %}
+                <height>{{model.height}}</height>
+                </polyline>
+              </geometry>
+            </visual>
+          </link>
+        </model>"""
+
+    def building_template(self):
+        return """
+          <model name="{{model.name}}">
+             <static>1</static>
+             <link name="{{model.name}}_link">
+                <pose frame="">
+                  {{model.origin.x}} {{model.origin.y}} {{model.origin.z}}
+                  0 0 0
+                </pose>
+                <collision name="{{model.name}}_collision">
+                   <geometry>
+                        <polyline>
+                        {% for vertex in model.vertices %}
+                          <point>{{vertex.x}} {{vertex.y}}</point>
+                        {% endfor %}
+                        <height>{{model.height}}</height>
+                        </polyline>
+                   </geometry>
+                </collision>
+                <visual name="{{model.name}}_visual">
+                   <material>
+                      <script>
+                        <uri>
+                          file://media/materials/scripts/gazebo.material
+                        </uri>
+                        <name>Gazebo/Grey</name>
+                      </script>
+                      <ambient>1 1 1 1</ambient>
+                   </material>
+                   <meta>
+                      <layer>0</layer>
+                   </meta>
+                   <geometry>
+                        <polyline>
+                        {% for vertex in model.vertices %}
+                          <point>{{vertex.x}} {{vertex.y}}</point>
+                        {% endfor %}
+                        <height>{{model.height}}</height>
+                        </polyline>
+                   </geometry>
+                </visual>
+             </link>
+          </model>"""
+
+    def ground_plane_template(self):
+        return """
+          <model name="{{model.name}}">
+            <static>1</static>
+            <pose frame=''>{{model.origin.x}} {{model.origin.y}} 0 0 0 0</pose>
+            <link name='{{model.name}}_link'>
+              <collision name='{{model.name}}'>
+                <geometry>
+                  <plane>
+                    <normal>0 0 1</normal>
+                    <size>{{model.size}} {{model.size}}</size>
+                  </plane>
+                </geometry>
+                <surface>
+                  <friction>
+                    <ode>
+                      <mu>100</mu>
+                      <mu2>50</mu2>
+                    </ode>
+                    <torsional>
+                      <ode/>
+                    </torsional>
+                  </friction>
+                  <contact>
+                    <ode/>
+                  </contact>
+                  <bounce/>
+                </surface>
+                <max_contacts>10</max_contacts>
+              </collision>
+              <visual name='{{model.name}}'>
+                <cast_shadows>0</cast_shadows>
+                <geometry>
+                  <plane>
+                    <normal>0 0 1</normal>
+                    <size>{{model.size}} {{model.size}}</size>
+                  </plane>
+                </geometry>
+                <material>
+                  <script>
+                    <uri>file://media/materials/scripts/gazebo.material</uri>
+                    <name>Gazebo/Grey</name>
+                  </script>
+                </material>
+                <transparency>1</transparency>
+              </visual>
+              <self_collide>0</self_collide>
+              <kinematic>0</kinematic>
+            </link>
+          </model>"""
+
+    def document_template(self):
+        return """
+        <?xml version="1.0" ?>
+        <sdf version="1.5">
+          {{inner_contents}}
+        </sdf>"""

--- a/terminus/generators/sdf_generator_gazebo_8.py
+++ b/terminus/generators/sdf_generator_gazebo_8.py
@@ -1,29 +1,15 @@
-from file_generator import FileGenerator
+from abstract_sdf_generator import AbstractSDFGenerator
 
 
-class SDFGeneratorGazebo8(FileGenerator):
+class SDFGeneratorGazebo8(AbstractSDFGenerator):
     """This class generates an sdf file that loads the road network from an RNDF
     file. In order to use this you will need Gazebo 8 and the plugin to render
     RNDF"""
 
-    def __init__(self, city, rndf_path):
+    def __init__(self, city, rndf_origin, rndf_path):
         super(SDFGeneratorGazebo8, self).__init__(city)
         self.rndf_path = rndf_path
-
-    def end_document(self):
-        self._wrap_document_with_template('document')
-
-    def end_city(self, city):
-        self._wrap_document_with_contents_for(city)
-
-    def end_block(self, block):
-        self._append_to_document(self._contents_for(block))
-
-    def end_building(self, building):
-        self._append_to_document(self._contents_for(building))
-
-    def end_ground_plane(self, ground_plane):
-        self._append_to_document(self._contents_for(ground_plane))
+        self.rndf_origin = rndf_origin
 
     def city_template(self):
         return """
@@ -44,154 +30,8 @@ class SDFGeneratorGazebo8(FileGenerator):
           <waypoints>true</waypoints>
           <junctions>true</junctions>
           <waypoints_material>Gazebo/White</waypoints_material>
+          <origin>{{generator.rndf_origin[0]}} {{generator.rndf_origin[1]}} 0.0</origin>
         </plugin>
           {{inner_contents}}
         </world>
         """
-
-    def block_template(self):
-        return """
-        <model name="{{model.name}}">
-          <static>1</static>
-          <allow_auto_disable>1</allow_auto_disable>
-          <link name="{{model.name}}_link">
-            <pose frame="">
-              {{model.origin.x}} {{model.origin.y}} {{model.origin.z}}
-              0 0 0
-            </pose>
-            <collision name="{{model.name}}_collision">
-              <geometry>
-                <polyline>
-                {% for vertex in model.vertices %}
-                  <point>{{vertex.x}} {{vertex.y}}</point>
-                {% endfor %}
-                <height>{{model.height}}</height>
-                </polyline>
-              </geometry>
-            </collision>
-            <visual name="{{model.name}}_visual">
-              <material>
-                <script>
-                  <uri>
-                    file://media/materials/scripts/gazebo.material
-                  </uri>
-                  <name>Gazebo/Grey</name>
-                </script>
-                <ambient>1 1 1 1</ambient>
-              </material>
-              <meta>
-                <layer>0</layer>
-              </meta>
-              <geometry>
-                <polyline>
-                {% for vertex in model.vertices %}
-                  <point>{{vertex.x}} {{vertex.y}}</point>
-                {% endfor %}
-                <height>{{model.height}}</height>
-                </polyline>
-              </geometry>
-            </visual>
-          </link>
-        </model>"""
-
-    def building_template(self):
-        return """
-          <model name="{{model.name}}">
-             <static>1</static>
-             <link name="{{model.name}}_link">
-                <pose frame="">
-                  {{model.origin.x}} {{model.origin.y}} {{model.origin.z}}
-                  0 0 0
-                </pose>
-                <collision name="{{model.name}}_collision">
-                   <geometry>
-                        <polyline>
-                        {% for vertex in model.vertices %}
-                          <point>{{vertex.x}} {{vertex.y}}</point>
-                        {% endfor %}
-                        <height>{{model.height}}</height>
-                        </polyline>
-                   </geometry>
-                </collision>
-                <visual name="{{model.name}}_visual">
-                   <material>
-                      <script>
-                        <uri>
-                          file://media/materials/scripts/gazebo.material
-                        </uri>
-                        <name>Gazebo/Grey</name>
-                      </script>
-                      <ambient>1 1 1 1</ambient>
-                   </material>
-                   <meta>
-                      <layer>0</layer>
-                   </meta>
-                   <geometry>
-                        <polyline>
-                        {% for vertex in model.vertices %}
-                          <point>{{vertex.x}} {{vertex.y}}</point>
-                        {% endfor %}
-                        <height>{{model.height}}</height>
-                        </polyline>
-                   </geometry>
-                </visual>
-             </link>
-          </model>"""
-
-    def ground_plane_template(self):
-        return """
-          <model name="{{model.name}}">
-            <static>1</static>
-            <pose frame=''>{{model.origin.x}} {{model.origin.y}} 0 0 0 0</pose>
-            <link name='{{model.name}}_link'>
-              <collision name='{{model.name}}'>
-                <geometry>
-                  <plane>
-                    <normal>0 0 1</normal>
-                    <size>{{model.size}} {{model.size}}</size>
-                  </plane>
-                </geometry>
-                <surface>
-                  <friction>
-                    <ode>
-                      <mu>100</mu>
-                      <mu2>50</mu2>
-                    </ode>
-                    <torsional>
-                      <ode/>
-                    </torsional>
-                  </friction>
-                  <contact>
-                    <ode/>
-                  </contact>
-                  <bounce/>
-                </surface>
-                <max_contacts>10</max_contacts>
-              </collision>
-              <visual name='{{model.name}}'>
-                <cast_shadows>0</cast_shadows>
-                <geometry>
-                  <plane>
-                    <normal>0 0 1</normal>
-                    <size>{{model.size}} {{model.size}}</size>
-                  </plane>
-                </geometry>
-                <material>
-                  <script>
-                    <uri>file://media/materials/scripts/gazebo.material</uri>
-                    <name>Gazebo/Grey</name>
-                  </script>
-                </material>
-                <transparency>1</transparency>
-              </visual>
-              <self_collide>0</self_collide>
-              <kinematic>0</kinematic>
-            </link>
-          </model>"""
-
-    def document_template(self):
-        return """
-        <?xml version="1.0" ?>
-        <sdf version="1.5">
-          {{inner_contents}}
-        </sdf>"""

--- a/terminus/generators/street_plot_generator.py
+++ b/terminus/generators/street_plot_generator.py
@@ -1,0 +1,27 @@
+from city_visitor import CityVisitor
+import matplotlib.pyplot as plt
+
+
+class StreetPlotGenerator(CityVisitor):
+
+    def write_to(self, destination_file):
+        plt.figure(figsize=(10, 10), dpi=100)
+        self.run()
+        plt.savefig(destination_file, dpi=100)
+
+    def draw_road(self, road):
+        x = []
+        y = []
+        for node in road.nodes:
+            center = node.center
+            x.append(center.x)
+            y.append(center.y)
+        return plt.plot(x, y)
+
+    def start_street(self, street):
+        line = self.draw_road(street)
+        plt.setp(line, linewidth=2)
+
+    def start_trunk(self, trunk):
+        line = self.draw_road(trunk)
+        plt.setp(line, linewidth=4)

--- a/terminus/run_generator.py
+++ b/terminus/run_generator.py
@@ -2,6 +2,7 @@
 
 from generators.rndf_generator import RNDFGenerator
 from generators.sdf_generator_gazebo_7 import SDFGeneratorGazebo7
+from generators.sdf_generator_gazebo_8 import SDFGeneratorGazebo8
 from generators.street_plot_generator import StreetPlotGenerator
 from builders import *
 
@@ -19,7 +20,7 @@ parser.add_argument('-b',
 # The output file
 parser.add_argument('-d',
                     '--destination',
-                    default='generated_worlds/city.sdf',
+                    default='generated_worlds/city',
                     help='destination file name')
 # Extra named parameters passed to the builder when creating it
 parser.add_argument('-p',
@@ -36,14 +37,12 @@ parser.add_argument('-x',
 
 arguments = parser.parse_args()
 
-# Get the file name to write to
-destination_sdf_file = arguments.destination
-
-# Get the base file name + path to also generate the rndf
-base_path = os.path.splitext(destination_sdf_file)[0]
+# Get the base file name + path to generate the different files
+base_path = arguments.destination
 
 destination_rndf_file = base_path + '.rndf'
-
+destination_sdf_7_file = base_path + '_gazebo_7.sdf'
+destination_sdf_8_file = base_path + '_gazebo_8.sdf'
 destination_street_plot_file = base_path + '_streets.png'
 
 # Get the class of the builder to use
@@ -64,7 +63,14 @@ builder = builder_class(**builder_parameters)
 city = builder.get_city()
 
 sdf_generator = SDFGeneratorGazebo7(city)
-sdf_generator.write_to(destination_sdf_file)
+sdf_generator.write_to(destination_sdf_7_file)
+
+# We are using a path that suits the Gazebo 8 plugin. This will change once
+# https://bitbucket.org/JChoclin/rndf_gazebo_plugin/issues/53/rndf-file-path-in-world-file
+# is fixed
+rndf_file_name = os.path.split(destination_rndf_file)[1]
+sdf_generator = SDFGeneratorGazebo8(city, '../example/' + rndf_file_name)
+sdf_generator.write_to(destination_sdf_8_file)
 
 if arguments.debug:
     street_plot_generator = StreetPlotGenerator(city)

--- a/terminus/run_generator.py
+++ b/terminus/run_generator.py
@@ -10,6 +10,9 @@ import argparse
 import sys
 import os
 
+# For the time being we use an arbitrary (lat,lon) pair as the origin
+RNDF_ORIGIN = (10, 65)
+
 parser = argparse.ArgumentParser()
 
 # The builder class
@@ -68,14 +71,15 @@ sdf_generator.write_to(destination_sdf_7_file)
 # We are using a path that suits the Gazebo 8 plugin. This will change once
 # https://bitbucket.org/JChoclin/rndf_gazebo_plugin/issues/53/rndf-file-path-in-world-file
 # is fixed
+# There is also an offset issue with RNDF vs Gazebo coordinates that will be fixed
+# in https://bitbucket.org/JChoclin/rndf_gazebo_plugin/issues/54/add-origin-node-to-world-description
 rndf_file_name = os.path.split(destination_rndf_file)[1]
-sdf_generator = SDFGeneratorGazebo8(city, '../example/' + rndf_file_name)
+sdf_generator = SDFGeneratorGazebo8(city, RNDF_ORIGIN, '../example/' + rndf_file_name)
 sdf_generator.write_to(destination_sdf_8_file)
 
 if arguments.debug:
     street_plot_generator = StreetPlotGenerator(city)
     street_plot_generator.write_to(destination_street_plot_file)
 
-# For the time being we use an arbitrary (lat,lon) pair as the origin
-rndf_generator = RNDFGenerator(city, Point(10, 65))
+rndf_generator = RNDFGenerator(city, Point(RNDF_ORIGIN[0], RNDF_ORIGIN[1]))
 rndf_generator.write_to(destination_rndf_file)

--- a/terminus/run_generator.py
+++ b/terminus/run_generator.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 
 from generators.rndf_generator import RNDFGenerator
-from generators.sdf_generator import SDFGenerator
+from generators.sdf_generator_gazebo_7 import SDFGeneratorGazebo7
+from generators.street_plot_generator import StreetPlotGenerator
 from builders import *
 
 import argparse
@@ -27,6 +28,11 @@ parser.add_argument('-p',
                     default='',
                     help='extra parameters to pass to the builder. Must be \
                     formatted as <key>=<value> pairs')
+# Extra named parameters passed to the builder when creating it
+parser.add_argument('-x',
+                    '--debug',
+                    action='store_true',
+                    help='Generates more output files, useful for debugging')
 
 arguments = parser.parse_args()
 
@@ -37,6 +43,8 @@ destination_sdf_file = arguments.destination
 base_path = os.path.splitext(destination_sdf_file)[0]
 
 destination_rndf_file = base_path + '.rndf'
+
+destination_street_plot_file = base_path + '_streets.png'
 
 # Get the class of the builder to use
 builder_class = getattr(sys.modules[__name__], arguments.builder)
@@ -55,8 +63,12 @@ builder = builder_class(**builder_parameters)
 
 city = builder.get_city()
 
-sdf_generator = SDFGenerator(city)
+sdf_generator = SDFGeneratorGazebo7(city)
 sdf_generator.write_to(destination_sdf_file)
+
+if arguments.debug:
+    street_plot_generator = StreetPlotGenerator(city)
+    street_plot_generator.write_to(destination_street_plot_file)
 
 # For the time being we use an arbitrary (lat,lon) pair as the origin
 rndf_generator = RNDFGenerator(city, Point(10, 65))


### PR DESCRIPTION
In this PR:

- Refactored SDF generators so we create SDF files for both Gazebo 7 with no plugin (using the old `<road>` tag) and Gazebo 8 with the RNDF plugin.
- Changed the `destination` parameter of the runner (no longer provide the file extension, as we are generating many files).
- Added a `--debug` flag to the command line runner, so we can generate more data for debugging. For the time being it is only a new file generated by matplotlib with the streets, each one with a different color.

Some captures of the generated files (note that there is an offset issue in Gazebo 8 + RNDF plugin. This will be addressed in https://bitbucket.org/JChoclin/rndf_gazebo_plugin/issues/54/add-origin-node-to-world-description)

RNDF:
![5x5rndf](https://cloud.githubusercontent.com/assets/4070228/21859170/6af62752-d80a-11e6-9854-df357cb071e5.png)

New debug output:
![city_streets](https://cloud.githubusercontent.com/assets/4070228/21859160/5fa54dba-d80a-11e6-8f4b-07a9805fdb5f.png)

Gazebo 7:
![5x5gazebo](https://cloud.githubusercontent.com/assets/4070228/21859186/7d41521a-d80a-11e6-9434-496fe6bb5260.png)

Gazebo 8 with RNDF plugin:
![sdfcapture](https://cloud.githubusercontent.com/assets/4070228/21859150/558c114c-d80a-11e6-848e-0236c13d8ba9.png)


