### PR TITLE
Change intersection api

### DIFF
--- a/terminus/builders/osm_city_builder.py
+++ b/terminus/builders/osm_city_builder.py
@@ -134,7 +134,7 @@ class OsmCityBuilder(object):
                     if self._is_coord_inside_bounds(ref_lat, ref_lon):
                         # If list is empty, use the node
                         if not coords_outside_box:
-                            tmp_road.add_node(SimpleNode.on(coord.x, coord.y, 0))
+                            tmp_road.add_point(Point(coord.x, coord.y, 0))
                             coord_inside_bounds = True
                             if self.nodes[ref][osmid] is None:
                                 self.nodes[ref][osmid] = tmp_road
@@ -149,7 +149,7 @@ class OsmCityBuilder(object):
                 # Add nodes if way runs in and out the bounding box
                 if road_in_and_out:
                     for coord in coords_outside_box:
-                        tmp_road.add_node(SimpleNode.on(coord.x, coord.y, 0))
+                        tmp_road.add_point(Point(coord.x, coord.y, 0))
                     if self.nodes[ref][osmid] is None:
                         self.nodes[ref][osmid] = tmp_road
                 # Check that road has at least two nodes
@@ -175,7 +175,7 @@ class OsmCityBuilder(object):
             roads = node.values()
             for index in range(len(roads)):
                 if roads[index] is not None and index < len(roads) - 1:
-                    roads[index].create_intersection(roads[index + 1], self.osm_coords[key]['point'])
+                    city.add_intersection_at(self.osm_coords[key]['point'])
 
     def _create_buildings(self, city):
         '''

--- a/terminus/builders/procedural_city/polygons_to_blocks_converter.py
+++ b/terminus/builders/procedural_city/polygons_to_blocks_converter.py
@@ -15,7 +15,7 @@ class PolygonsToBlocksConverter(object):
 
     def _polygon_to_block(self, polygon):
         """Create a Block based on a Shapely polygon"""
-        points = list(Point(c) for c in polygon.exterior.coords)
+        points = list(Point(c[0], c[1]) for c in polygon.exterior.coords)
         return Block(Point(0, 0, 0), points)
 
     def _reduce_adjacent_polygons(self, polygons):

--- a/terminus/builders/procedural_city_builder.py
+++ b/terminus/builders/procedural_city_builder.py
@@ -42,8 +42,7 @@ class ProceduralCityBuilder(object):
             self._generate_procedural_city()
 
         vertices = self._parse_vertices_file()
-        for road in self._build_roads(vertices):
-            city.add_road(road)
+        self._build_roads(city, vertices)
 
         polygons = self._parse_polygons_file()
         for block in self._build_blocks(polygons):
@@ -52,7 +51,7 @@ class ProceduralCityBuilder(object):
         city.set_ground_plane(GroundPlane(100, Point(0, 0, 0)))
         return city
 
-    def _build_roads(self, vertex_list):
+    def _build_roads(self, city, vertex_list):
         vertex_mapping = {}
         for vertex in vertex_list:
             vertex_mapping[vertex] = GraphNode.from_vertex(vertex, self.ratio)
@@ -62,8 +61,8 @@ class ProceduralCityBuilder(object):
             node.set_neighbours(node_neighbours)
 
         # 0.79 rad ~ 45 deg
-        converter = VertexGraphToRoadsConverter(0.79, vertex_mapping.values())
-        return converter.get_roads()
+        converter = VertexGraphToRoadsConverter(city, 0.79, vertex_mapping.values())
+        converter.run()
 
     def _build_blocks(self, polygon_list):
         lot_polygons = filter(lambda polygon: polygon.is_lot(), polygon_list)

--- a/terminus/builders/simple_city_builder.py
+++ b/terminus/builders/simple_city_builder.py
@@ -18,16 +18,19 @@ class SimpleCityBuilder(object):
         self.multiplier = 100
 
         self._create_ground_plane(city, size)
-        self._setup_intersections(size)
+        self._setup_intersections(city, size)
         self._create_inner_streets(city, size)
         self._create_surrounding_ring_road(city, size)
         self._create_blocks(city, size)
         self._create_buildings(city, size)
         return city
 
-    def _setup_intersections(self, size):
-        self.intersections = [[IntersectionNode.on(self.multiplier * x, self.multiplier * y, 0)
+    def _setup_intersections(self, city, size):
+        self.intersections = [[Point(self.multiplier * x, self.multiplier * y, 0)
                               for y in range(size)] for x in range(size)]
+        for x in range(size):
+            for y in range(size):
+                city.add_intersection_at(self.intersections[x][y])
 
     def _create_ground_plane(self, city, size):
         ground_plane_size = size * self.multiplier
@@ -44,46 +47,46 @@ class SimpleCityBuilder(object):
         for x in range(1, size - 1):
             road = Street()
             for y in range(size):
-                road.add_node(self.intersections[x][y])
+                road.add_point(self.intersections[x][y])
             city.add_road(road)
 
         # Horizontal
         for y in range(1, size - 1):
             road = Street()
             for x in range(size):
-                road.add_node(self.intersections[x][y])
+                road.add_point(self.intersections[x][y])
             city.add_road(road)
 
         # Diagonals
         road = Street()
         for i in range(size):
-            road.add_node(self.intersections[i][i])
+            road.add_point(self.intersections[i][i])
         city.add_road(road)
 
         road = Street()
         for i in range(size):
-            road.add_node(self.intersections[i][size - i - 1])
+            road.add_point(self.intersections[i][size - i - 1])
         city.add_road(road)
 
     def _create_surrounding_ring_road(self, city, size):
         ring_road_1 = Street(name='RingRoad1')
         for x in range(size):
-            ring_road_1.add_node(self.intersections[x][0])
+            ring_road_1.add_point(self.intersections[x][0])
         city.add_road(ring_road_1)
 
         ring_road_2 = Street(name='RingRoad2')
         for y in range(size):
-            ring_road_2.add_node(self.intersections[size - 1][y])
+            ring_road_2.add_point(self.intersections[size - 1][y])
         city.add_road(ring_road_2)
 
         ring_road_3 = Street(name='RingRoad3')
         for x in range(size):
-            ring_road_3.add_node(self.intersections[size - x - 1][size - 1])
+            ring_road_3.add_point(self.intersections[size - x - 1][size - 1])
         city.add_road(ring_road_3)
 
         ring_road_4 = Street(name='RingRoad4')
         for y in range(size):
-            ring_road_4.add_node(self.intersections[0][size - y - 1])
+            ring_road_4.add_point(self.intersections[0][size - y - 1])
         city.add_road(ring_road_4)
 
     def _create_blocks(self, city, size):

--- a/terminus/geometry/point.py
+++ b/terminus/geometry/point.py
@@ -1,12 +1,53 @@
+import math
 import shapely.geometry
-from monkeypatch import monkeypatch_method
-
-Point = shapely.geometry.Point
+from numbers import Number
 
 
-@monkeypatch_method(Point)
-def __hash__(self):
-    if self._ndim == 3:
-        return hash((self.x, self.y, self.z))
-    else:
-        return hash((self.x, self.y))
+class Point(object):
+    def __init__(self, x, y, z=0):
+        self.x = x
+        self.y = y
+        self.z = z
+
+    @classmethod
+    def from_shapely(cls, shapely_point):
+        if shapely_point._ndim == 3:
+            return cls(shapely_point.x, shapely_point.y, shapely_point.z)
+        else:
+            return cls(shapely_point.x, shapely_point.y)
+
+    def to_shapely_point(self):
+        return shapely.geometry.Point(self.x, self.y, self.z)
+
+    def to_tuple(self):
+        return (self.x, self.y, self.z)
+
+    def __eq__(self, other):
+        return self.x == other.x and self.y == other.y and self.z == other.z
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return hash(self.x) ^ hash(self.y) ^ hash(self.z)
+
+    def __repr__(self):
+        return "Point({0}, {1}, {2})".format(self.x, self.y, self.z)
+
+    def __add__(self, other):
+        return Point(self.x + other.x, self.y + other.y, self.z + other.z)
+
+    def __sub__(self, other):
+        return Point(self.x - other.x, self.y - other.y, self.z - other.z)
+
+    def __mul__(self, other):
+        if isinstance(other, Number):
+            return Point(self.x * other, self.y * other, self.z * other)
+        else:
+            return Point(self.x * other.x, self.y * other.y, self.z * other.z)
+
+    def __div__(self, other):
+        if isinstance(other, Number):
+            return Point(self.x / other, self.y / other, self.z / other)
+        else:
+            return Point(self.x / other.x, self.y / other.y, self.z / other.z)

--- a/terminus/geometry/point.py
+++ b/terminus/geometry/point.py
@@ -29,7 +29,7 @@ class Point(object):
         return not self.__eq__(other)
 
     def __hash__(self):
-        return hash(self.x) ^ hash(self.y) ^ hash(self.z)
+        return hash((hash(self.x) << 4) + hash(self.y) + (hash(self.z) ^ 0xFFFFFF))
 
     def __repr__(self):
         return "Point({0}, {1}, {2})".format(self.x, self.y, self.z)

--- a/terminus/models/city.py
+++ b/terminus/models/city.py
@@ -1,5 +1,6 @@
 from city_model import CityModel
 from datetime import date
+from models.road import *
 
 
 # For the time being, the city will be our Gazebo world
@@ -10,12 +11,19 @@ class City(CityModel):
         self.roads = []
         self.blocks = []
         self.buildings = []
+        self.intersections = {}
 
     def set_ground_plane(self, ground_plane):
         self.ground_plane = ground_plane
 
     def add_road(self, road):
         self.roads.append(road)
+        # We assume there will be globally way more intersections than nodes
+        # in a street
+        for node in road.nodes:
+            if node.center in self.intersections:
+                intersection = self.intersections[node.center]
+                road.replace_node_at(node.center, intersection)
 
     def roads_count(self):
         return len(self.roads)
@@ -25,6 +33,16 @@ class City(CityModel):
 
     def add_building(self, building):
         self.buildings.append(building)
+
+    def add_intersection_at(self, point):
+        if point not in self.intersections:
+            intersection = IntersectionNode(point)
+            # Register intersection
+            self.intersections[point] = intersection
+            # Add to it existing roads that include that point
+            for road in self.roads:
+                if road.includes_point(point):
+                    road.replace_node_at(point, intersection)
 
     def accept(self, generator):
         generator.start_city(self)

--- a/terminus/tests/city_test.py
+++ b/terminus/tests/city_test.py
@@ -1,0 +1,58 @@
+import unittest
+
+from geometry.point import Point
+from models.city import City
+from models.road import *
+from models.street import Street
+
+
+class CityTest(unittest.TestCase):
+
+    def setUp(self):
+        self.city = City()
+
+    def test_add_intersection_at_on_single_street(self):
+        '''Even if we only add a single street (hence there is no other
+        street to intersect with) the intersection is created'''
+
+        self.city.add_intersection_at(Point(0, 0))
+        street = Street.from_points([Point(0, 0), Point(100, 0)])
+        self.city.add_road(street)
+        self.assertEquals(street.nodes[0], IntersectionNode.on(0, 0))
+        self.assertEquals(street.nodes[1], SimpleNode.on(100, 0))
+
+    def test_add_intersection_at_is_order_independent(self):
+        '''No matter if we create the intersection before or after adding the
+        street, the nodes are properly setup'''
+
+        self.city.add_intersection_at(Point(0, 0))
+        street = Street.from_points([Point(0, 0), Point(100, 0)])
+        self.city.add_road(street)
+        self.city.add_intersection_at(Point(100, 0))
+        self.assertEquals(street.nodes[0], IntersectionNode.on(0, 0))
+        self.assertEquals(street.nodes[1], IntersectionNode.on(100, 0))
+
+    def test_add_intersection_at_on_two_streets(self):
+        '''Check that both streets get the intersection node and that
+        the same node is shared between them'''
+
+        self.city.add_intersection_at(Point(0, 0))
+        street1 = Street.from_points([Point(0, 0), Point(100, 0)])
+        street2 = Street.from_points([Point(0, 0), Point(100, 100)])
+        self.city.add_road(street1)
+        self.city.add_road(street2)
+        expected_node = IntersectionNode.on(0, 0)
+        self.assertEquals(street1.nodes[0], expected_node)
+        self.assertEquals(street2.nodes[0], expected_node)
+        self.assertTrue(street1.nodes[0] is street2.nodes[0])
+
+    def test_add_intersection_at_on_different_z_order(self):
+        '''Check that the z component of the point does make a difference'''
+
+        self.city.add_intersection_at(Point(0, 0))
+        street1 = Street.from_points([Point(0, 0), Point(100, 0)])
+        street2 = Street.from_points([Point(0, 0, 1), Point(100, 100)])
+        self.city.add_road(street1)
+        self.city.add_road(street2)
+        self.assertEquals(street1.nodes[0], IntersectionNode.on(0, 0))
+        self.assertEquals(street2.nodes[0], SimpleNode.on(0, 0, 1))

--- a/terminus/tests/rndf_generator_test.py
+++ b/terminus/tests/rndf_generator_test.py
@@ -41,10 +41,10 @@ class RNDFGeneratorTest(unittest.TestCase):
 
     def test_simple_street(self):
         city = City("Single street")
-        street = Street.from_nodes([
-            SimpleNode.on(0, 0),
-            SimpleNode.on(1000, 0),
-            SimpleNode.on(2000, 0)
+        street = Street.from_points([
+            Point(0, 0),
+            Point(1000, 0),
+            Point(2000, 0)
         ])
         street.name = "s1"
         city.add_road(street)
@@ -75,21 +75,15 @@ class RNDFGeneratorTest(unittest.TestCase):
              (0,-1)
         """
         city = City("Cross")
-        intersection = IntersectionNode.on(0, 0)
 
-        s1 = Street.from_nodes([
-            SimpleNode.on(-1000, 0),
-            intersection,
-            SimpleNode.on(1000, 0)
-        ])
+        s1 = Street.from_points([Point(-1000, 0), Point(0, 0), Point(1000, 0)])
         s1.name = "s1"
 
-        s2 = Street.from_nodes([
-            SimpleNode.on(0, 1000),
-            intersection,
-            SimpleNode.on(0, -1000)
-        ])
+        s2 = Street.from_points([Point(0, 1000), Point(0, 0), Point(0, -1000)])
         s2.name = "s2"
+
+        city.add_intersection_at(Point(0, 0))
+
         city.add_road(s1)
         city.add_road(s2)
 
@@ -134,13 +128,15 @@ class RNDFGeneratorTest(unittest.TestCase):
                +  (1,0)
         """
         city = City("LCross")
-        intersection = IntersectionNode.on(0, 0)
 
-        s1 = Street.from_nodes([SimpleNode.on(0, 1000), intersection])
+        s1 = Street.from_points([Point(0, 1000), Point(0, 0)])
         s1.name = "s1"
 
-        s2 = Street.from_nodes([intersection, SimpleNode.on(1000, 0)])
+        s2 = Street.from_points([Point(0, 0), Point(1000, 0)])
         s2.name = "s2"
+
+        city.add_intersection_at(Point(0, 0))
+
         city.add_road(s1)
         city.add_road(s2)
 
@@ -183,16 +179,17 @@ class RNDFGeneratorTest(unittest.TestCase):
             (-1,-1)   (1,-1)
         """
         city = City("YCross")
-        intersection = IntersectionNode.on(0, 0)
 
-        s1 = Street.from_nodes([SimpleNode.on(0, 1000), intersection])
+        s1 = Street.from_points([Point(0, 1000), Point(0, 0)])
         s1.name = "s1"
 
-        s2 = Street.from_nodes([intersection, SimpleNode.on(-1000, -1000)])
+        s2 = Street.from_points([Point(0, 0), Point(-1000, -1000)])
         s2.name = "s2"
 
-        s3 = Street.from_nodes([intersection, SimpleNode.on(1000, -1000)])
+        s3 = Street.from_points([Point(0, 0), Point(1000, -1000)])
         s3.name = "s3"
+
+        city.add_intersection_at(Point(0, 0))
 
         city.add_road(s1)
         city.add_road(s2)
@@ -249,20 +246,21 @@ class RNDFGeneratorTest(unittest.TestCase):
             (-1,-1)   (1,-1)
         """
         city = City("YCross")
-        intersection = IntersectionNode.on(0, 0)
 
-        s1 = Street.from_nodes([intersection, SimpleNode.on(0, 1000)])
+        s1 = Street.from_points([Point(0, 0), Point(0, 1000)])
         s1.name = "s1"
 
-        s2 = Street.from_nodes([SimpleNode.on(-1000, -1000), intersection])
+        s2 = Street.from_points([Point(-1000, -1000), Point(0, 0)])
         s2.name = "s2"
 
-        s3 = Street.from_nodes([SimpleNode.on(1000, -1000), intersection])
+        s3 = Street.from_points([Point(1000, -1000), Point(0, 0)])
         s3.name = "s3"
 
         city.add_road(s1)
         city.add_road(s2)
         city.add_road(s3)
+
+        city.add_intersection_at(Point(0, 0))
 
         self._generate_rndf(city)
         self._assert_contents_are("""

--- a/terminus/tests/vertex_graph_to_roads_converter_test.py
+++ b/terminus/tests/vertex_graph_to_roads_converter_test.py
@@ -6,12 +6,16 @@ from geometry.point import Point
 from models.road import *
 from models.street import Street
 from models.trunk import Trunk
+from models.city import City
 
 STREET_WIDTH = 4
 TRUNK_WIDTH = 22
 
 
 class VertexGraphToRoadsConverterTest(unittest.TestCase):
+
+    def setUp(self):
+        self.city = City()
 
     def test_get_roads_one_aligned_segment(self):
         """
@@ -22,13 +26,13 @@ class VertexGraphToRoadsConverterTest(unittest.TestCase):
 
         self._connect(n1, n2)
 
-        self.converter = VertexGraphToRoadsConverter(0.25, [n1, n2])
-        roads = self.converter.get_roads()
+        VertexGraphToRoadsConverter(self.city, 0.25, [n1, n2]).run()
+
         expected_roads = [
             Street.from_nodes([SimpleNode.on(0, 0), SimpleNode.on(1, 0)])
         ]
         self._set_roads_width(expected_roads)
-        self.assertItemsEqual(roads, expected_roads)
+        self.assertItemsEqual(self.city.roads, expected_roads)
 
     def test_get_roads_one_not_aligned_segment(self):
         """
@@ -41,13 +45,13 @@ class VertexGraphToRoadsConverterTest(unittest.TestCase):
 
         self._connect(n1, n2)
 
-        self.converter = VertexGraphToRoadsConverter(0.25, [n1, n2])
-        roads = self.converter.get_roads()
+        VertexGraphToRoadsConverter(self.city, 0.25, [n1, n2]).run()
+
         expected_roads = [
             Street.from_nodes([SimpleNode.on(0, 0), SimpleNode.on(1, 1)])
         ]
         self._set_roads_width(expected_roads)
-        self.assertItemsEqual(roads, expected_roads)
+        self.assertItemsEqual(self.city.roads, expected_roads)
 
     def test_get_roads_multiple_aligned_segments(self):
         """
@@ -62,8 +66,8 @@ class VertexGraphToRoadsConverterTest(unittest.TestCase):
         self._connect(n2, n3)
         self._connect(n3, n4)
 
-        self.converter = VertexGraphToRoadsConverter(0.25, [n1, n2, n3, n4])
-        roads = self.converter.get_roads()
+        VertexGraphToRoadsConverter(self.city, 0.25, [n1, n2, n3, n4]).run()
+
         expected_roads = [
             Street.from_nodes([
                 SimpleNode.on(0, 0),
@@ -73,7 +77,7 @@ class VertexGraphToRoadsConverterTest(unittest.TestCase):
             ])
         ]
         self._set_roads_width(expected_roads)
-        self.assertItemsEqual(roads, expected_roads)
+        self.assertItemsEqual(self.city.roads, expected_roads)
 
     def test_get_roads_multiple_non_aligned_segments(self):
         """
@@ -89,15 +93,15 @@ class VertexGraphToRoadsConverterTest(unittest.TestCase):
         self._connect(n2, n3)
         self._connect(n3, n4)
 
-        self.converter = VertexGraphToRoadsConverter(0.25, [n1, n2, n3, n4])
-        roads = self.converter.get_roads()
+        VertexGraphToRoadsConverter(self.city, 0.25, [n1, n2, n3, n4]).run()
+
         intersection = IntersectionNode.on(5, 1)
         expected_roads = [
             Street.from_nodes([SimpleNode.on(0, 0), SimpleNode.on(1, 0), intersection]),
             Street.from_nodes([SimpleNode.on(6, 2), intersection])
         ]
         self._set_roads_width(expected_roads)
-        self.assertItemsEqual(roads, expected_roads)
+        self.assertItemsEqual(self.city.roads, expected_roads)
 
     def test_get_roads_multiple_independent_segments(self):
         """
@@ -114,15 +118,14 @@ class VertexGraphToRoadsConverterTest(unittest.TestCase):
         self._connect(n2, n3)
         self._connect(n4, n5)
 
-        self.converter = VertexGraphToRoadsConverter(
-            0.25, [n1, n2, n3, n4, n5])
-        roads = self.converter.get_roads()
+        VertexGraphToRoadsConverter(self.city, 0.25, [n1, n2, n3, n4, n5]).run()
+
         expected_roads = [
             Street.from_nodes([SimpleNode.on(0, 0), SimpleNode.on(1, 0), SimpleNode.on(6, 1)]),
             Street.from_nodes([SimpleNode.on(2, 5), SimpleNode.on(3, 4)])
         ]
         self._set_roads_width(expected_roads)
-        self.assertItemsEqual(roads, expected_roads)
+        self.assertItemsEqual(self.city.roads, expected_roads)
 
     def test_get_roads_V_type(self):
         """
@@ -136,15 +139,14 @@ class VertexGraphToRoadsConverterTest(unittest.TestCase):
         self._connect(n1, n2)
         self._connect(n1, n3)
 
-        self.converter = VertexGraphToRoadsConverter(0.25, [n1, n2, n3])
-        roads = self.converter.get_roads()
+        VertexGraphToRoadsConverter(self.city, 0.25, [n1, n2, n3]).run()
         intersection = IntersectionNode.on(0, 0)
         expected_roads = [
-            Street.from_nodes([SimpleNode.on(3, -1), intersection]),
-            Street.from_nodes([SimpleNode.on(3, 1), intersection])
+            Street.from_nodes([SimpleNode.on(3, 1), intersection]),
+            Street.from_nodes([SimpleNode.on(3, -1), intersection])
         ]
         self._set_roads_width(expected_roads)
-        self.assertItemsEqual(roads, expected_roads)
+        self.assertItemsEqual(self.city.roads, expected_roads)
 
     def test_get_roads_L_type(self):
         """
@@ -161,15 +163,14 @@ class VertexGraphToRoadsConverterTest(unittest.TestCase):
         self._connect(n2, n3)
         self._connect(n2, n4)
 
-        self.converter = VertexGraphToRoadsConverter(0.25, [n1, n2, n3, n4])
-        roads = self.converter.get_roads()
+        VertexGraphToRoadsConverter(self.city, 0.25, [n1, n2, n3, n4]).run()
         intersection = IntersectionNode.on(1, 0)
         expected_roads = [
             Street.from_nodes([SimpleNode.on(0, 0), intersection, SimpleNode.on(6, 1)]),
             Street.from_nodes([SimpleNode.on(6, 6), intersection])
         ]
         self._set_roads_width(expected_roads)
-        self.assertItemsEqual(roads, expected_roads)
+        self.assertItemsEqual(self.city.roads, expected_roads)
 
     def test_get_roads_Y_type(self):
         """
@@ -187,15 +188,14 @@ class VertexGraphToRoadsConverterTest(unittest.TestCase):
         self._connect(n2, n3)
         self._connect(n2, n4)
 
-        self.converter = VertexGraphToRoadsConverter(0.25, [n1, n2, n3, n4])
-        roads = self.converter.get_roads()
+        VertexGraphToRoadsConverter(self.city, 0.25, [n1, n2, n3, n4]).run()
         intersection = IntersectionNode.on(1, 0)
         expected_roads = [
             Street.from_nodes([SimpleNode.on(0, 0), intersection, SimpleNode.on(6, -0.8)]),
             Street.from_nodes([SimpleNode.on(6, 1), intersection])
         ]
         self._set_roads_width(expected_roads)
-        self.assertItemsEqual(roads, expected_roads)
+        self.assertItemsEqual(self.city.roads, expected_roads)
 
     def test_get_roads_matrix_distribution(self):
         """
@@ -230,9 +230,7 @@ class VertexGraphToRoadsConverterTest(unittest.TestCase):
         self._connect(n7, n8)
         self._connect(n8, n9)
 
-        self.converter = VertexGraphToRoadsConverter(
-            0.25, [n1, n2, n3, n4, n5, n6, n7, n8, n9])
-        roads = self.converter.get_roads()
+        VertexGraphToRoadsConverter(self.city, 0.25, [n1, n2, n3, n4, n5, n6, n7, n8, n9]).run()
         j1 = IntersectionNode.on(0, 0)
         j2 = IntersectionNode.on(1, 0)
         j3 = IntersectionNode.on(2, 0)
@@ -251,7 +249,7 @@ class VertexGraphToRoadsConverterTest(unittest.TestCase):
             Street.from_nodes([j7, j8, j9])
         ]
         self._set_roads_width(expected_roads)
-        self.assertItemsEqual(roads, expected_roads)
+        self.assertItemsEqual(self.city.roads, expected_roads)
 
     def test_get_roads_Y_street_best_neighbour_trunk(self):
         """
@@ -270,15 +268,14 @@ class VertexGraphToRoadsConverterTest(unittest.TestCase):
         self._connect(n2, v3)
         self._connect(n2, n4)
 
-        self.converter = VertexGraphToRoadsConverter(0.25, [n1, n2, v3, n4])
-        roads = self.converter.get_roads()
+        VertexGraphToRoadsConverter(self.city, 0.25, [n1, n2, v3, n4]).run()
         intersection = IntersectionNode.on(1, 0)
         expected_roads = [
             Street.from_nodes([SimpleNode.on(0, 0), intersection, SimpleNode.on(6, 1)]),
             Street.from_nodes([intersection, SimpleNode.on(6, -0.8)])
         ]
         self._set_roads_width(expected_roads)
-        self.assertItemsEqual(roads, expected_roads)
+        self.assertItemsEqual(self.city.roads, expected_roads)
 
     def test_get_roads_Y_street_best_neighbour_street(self):
         """
@@ -297,15 +294,14 @@ class VertexGraphToRoadsConverterTest(unittest.TestCase):
         self._connect(n2, n3)
         self._connect(n2, n4)
 
-        self.converter = VertexGraphToRoadsConverter(0.25, [n1, n2, n3, n4])
-        roads = self.converter.get_roads()
+        VertexGraphToRoadsConverter(self.city, 0.25, [n1, n2, n3, n4]).run()
         intersection = IntersectionNode.on(1, 0)
         expected_roads = [
             Street.from_nodes([SimpleNode.on(0, 0), intersection, SimpleNode.on(6, -0.8)]),
             Street.from_nodes([intersection, SimpleNode.on(6, 1)])
         ]
         self._set_roads_width(expected_roads)
-        self.assertItemsEqual(roads, expected_roads)
+        self.assertItemsEqual(self.city.roads, expected_roads)
 
     def test_get_roads_pipe_street_into_trunk(self):
         """
@@ -320,13 +316,12 @@ class VertexGraphToRoadsConverterTest(unittest.TestCase):
         self._connect(n1, n2)
         self._connect(n2, n3)
 
-        self.converter = VertexGraphToRoadsConverter(0.25, [n1, n2, n3])
-        roads = self.converter.get_roads()
+        VertexGraphToRoadsConverter(self.city, 0.25, [n1, n2, n3]).run()
         expected_roads = [
             Street.from_nodes([SimpleNode.on(0, 0), SimpleNode.on(1, 0), SimpleNode.on(6, 0)])
         ]
         self._set_roads_width(expected_roads)
-        self.assertItemsEqual(roads, expected_roads)
+        self.assertItemsEqual(self.city.roads, expected_roads)
 
     def test_get_roads_pipe_trunk_into_street(self):
         """
@@ -343,15 +338,15 @@ class VertexGraphToRoadsConverterTest(unittest.TestCase):
         self._connect(n1, n2)
         self._connect(n2, n3)
 
-        self.converter = VertexGraphToRoadsConverter(0.25, [n1, n2, n3])
-        roads = self.converter.get_roads()
+        VertexGraphToRoadsConverter(self.city, 0.25, [n1, n2, n3]).run()
+
         intersection = IntersectionNode.on(1, 0)
         expected_roads = [
-            Trunk.from_nodes([SimpleNode.on(0, 0), intersection]),
-            Street.from_nodes([SimpleNode.on(6, 0), intersection])
+            Street.from_nodes([SimpleNode.on(6, 0), intersection]),
+            Trunk.from_nodes([SimpleNode.on(0, 0), intersection])
         ]
         self._set_roads_width(expected_roads)
-        self.assertItemsEqual(roads, expected_roads)
+        self.assertItemsEqual(self.city.roads, expected_roads)
 
     def _connect(self, n1, n2):
         """Make a bidirectional connection between two nodes"""


### PR DESCRIPTION
In this PR:

- Encapsulate how intersections are created. We now just do `city.add_intersection_at(Point(x, y))` and it will create the intersection on any existing roads and on any road that is further added to the city.
- As a consequence of the former we also encapsulate node management, hence the preferred way of dealing with roads is by specifying their points (i.e. we just define the geometry and let it work out which nodes will be used internally).
- Finally, stop using shapely points as they were terribly inefficient for repeated (but basic) computations like `==` or `hash` (got ~2.5x improvement in times by switching to our implementation).