### PR TITLE
Issue/#149 kickoff opendrive model exporter

### DIFF
--- a/terminus/generators/opendrive_generator.py
+++ b/terminus/generators/opendrive_generator.py
@@ -49,11 +49,13 @@ class OpenDriveGenerator(FileGenerator):
             {% set points = generator._get_waypoint_positions(model.get_waypoints()) %}
             {% set distances = generator._get_distances(points) %}
             {% set total_length = generator._road_length(distances) %}
+            {% set angles = generator._yaws(points) %}
+            {% set last_distance = 0.0 %}
             <road name="{{model.name}}" length="{{total_length}}" id="{{segment_id}}">
               <type s="0.0000000000000000e+00" type="town"/>
               <planView>
               {% for i in range(generator._collection_size(points) - 1)    %}
-                <geometry s="0.0000000000000000e+00" x="{{points[i].x}}" y="{{points[i].y}}" hdg="5.4977871437752235e+00" length="{{distances[i]}}">
+                <geometry s="{{generator._road_length(distances[:i])}}" x="{{points[i].x}}" y="{{points[i].y}}" hdg="{{angles[i]}}" length="{{distances[i]}}">
                   <line/>
               {% endfor %}
                   </geometry>
@@ -104,3 +106,15 @@ class OpenDriveGenerator(FileGenerator):
 
     def _collection_size(self, collection):
         return len(collection)
+
+    def _yaw(self, pA, pB):
+        dX = pB.x - pA.x
+        dY = pB.y - pA.y
+        return math.atan2(dY, dX)
+
+    def _yaws(self, points):
+        yaws = []
+        for i in range(len(points) - 1):
+            yaws.append(self._yaw(points[i], points[i + 1]))
+        yaws.append(yaws[-1])
+        return yaws

--- a/terminus/generators/opendrive_generator.py
+++ b/terminus/generators/opendrive_generator.py
@@ -46,7 +46,7 @@ class OpenDriveGenerator(FileGenerator):
 
     def street_template(self):
         return """
-            <road name="" length="10.0" id="500">
+            <road name="{{segment_id}}" length="10.0" id="500">
               <type s="0.0000000000000000e+00" type="town"/>
               <planView>
                   <geometry s="0.0000000000000000e+00" x="-7.0710678117841717e+00" y="7.0710678119660715e+00" hdg="5.4977871437752235e+00" length="10.0">

--- a/terminus/generators/opendrive_generator.py
+++ b/terminus/generators/opendrive_generator.py
@@ -43,7 +43,7 @@ class OpenDriveGenerator(FileGenerator):
         </OpenDRIVE>"""
 
     # We don't have support for multilane roads, so we should
-    # correct the lane creation for roads. We are creating only on lane to the
+    # correct the lane creation for roads. We are creating only one lane to the
     # right of the base line and no offset is set.
     def road_template(self):
         return """

--- a/terminus/generators/opendrive_generator.py
+++ b/terminus/generators/opendrive_generator.py
@@ -39,7 +39,7 @@ class OpenDriveGenerator(FileGenerator):
         return """
         <?xml version="1.0" standalone="yes"?>
           <OpenDRIVE xmlns="http://www.opendrive.org">
-            <header revMajor="1" revMinor="1" name="" version="1.00" north="0.0000000000000000e+00" south="0.0000000000000000e+00" east="0.0000000000000000e+00" west="0.0000000000000000e+00" maxRoad="{{model.roads_count()}}" maxJunc="0" maxPrg="0">
+            <header revMajor="1" revMinor="1" name="{{model.name}}" version="1.00" north="0.0000000000000000e+00" south="0.0000000000000000e+00" east="0.0000000000000000e+00" west="0.0000000000000000e+00" maxRoad="{{model.roads_count()}}" maxJunc="0" maxPrg="0">
             </header>
             {{inner_contents}}
         </OpenDRIVE>"""

--- a/terminus/generators/opendrive_generator.py
+++ b/terminus/generators/opendrive_generator.py
@@ -115,5 +115,4 @@ class OpenDriveGenerator(FileGenerator):
         yaws = []
         for i in range(len(points) - 1):
             yaws.append(self._yaw(points[i], points[i + 1]))
-        yaws.append(yaws[-1])
         return yaws

--- a/terminus/generators/opendrive_generator.py
+++ b/terminus/generators/opendrive_generator.py
@@ -42,6 +42,9 @@ class OpenDriveGenerator(FileGenerator):
             {{inner_contents}}
         </OpenDRIVE>"""
 
+    # We don't have support for multilane roads, so we should
+    # correct the lane creation for roads. We are creating only on lane to the
+    # right of the base line and no offset is set.
     def road_template(self):
         return """
             {% set points = model.get_waypoint_positions() %}
@@ -70,20 +73,12 @@ class OpenDriveGenerator(FileGenerator):
                               <roadMark sOffset="0.0000000000000000e+00" type="none" weight="standard" color="standard" width="1.3000000000000000e-01"/>
                           </lane>
                       </center>
-                      <left>
-                          <lane id="1" type="driving" level= "0">
-                              <link>
-                              </link>
-                              <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.3000000000000000e-01"/>
-                              <width sOffset="0.0000000000000000e+00" a="{{model.get_width()/2.0}}" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
-                          </lane>
-                      </left>
                       <right>
                           <lane id="-1" type="driving" level= "0">
                               <link>
                               </link>
                               <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.3000000000000000e-01"/>
-                              <width sOffset="0.0000000000000000e+00" a="{{model.get_width()/2.0}}" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                              <width sOffset="0.0000000000000000e+00" a="{{model.get_width()}}" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
                           </lane>
                       </right>
                   </laneSection>

--- a/terminus/generators/opendrive_generator.py
+++ b/terminus/generators/opendrive_generator.py
@@ -13,12 +13,10 @@ class OpenDriveGenerator(FileGenerator):
         self.origin = origin
         self.id_mapper = OpenDriveIdMapper(city)
 
-    # # Start/End document handling
     def start_document(self):
         self.id_mapper.run()
 
     def end_city(self, city):
-        print "Finishing doc"
         self._wrap_document_with_contents_for(city)
 
     def start_street(self, street):
@@ -44,7 +42,7 @@ class OpenDriveGenerator(FileGenerator):
             {{inner_contents}}
         </OpenDRIVE>"""
 
-    def street_template(self):
+    def road_template(self):
         return """
             {% set points = generator._get_waypoint_positions(model.get_waypoints()) %}
             {% set distances = generator._get_distances(points) %}
@@ -97,8 +95,11 @@ class OpenDriveGenerator(FileGenerator):
               </signals>
             </road>"""
 
+    def street_template(self):
+        return self.road_template()
+
     def trunk_template(self):
-        return self.street_template()
+        return self.road_template()
 
     def _distance(self, pA, pB):
         return math.sqrt(math.pow(pA.x - pB.x, 2.0) + math.pow(pA.y - pB.y, 2.0))

--- a/terminus/generators/opendrive_generator.py
+++ b/terminus/generators/opendrive_generator.py
@@ -44,15 +44,14 @@ class OpenDriveGenerator(FileGenerator):
 
     def road_template(self):
         return """
-            {% set points = generator._get_waypoint_positions(model.get_waypoints()) %}
-            {% set distances = generator._get_distances(points) %}
-            {% set total_length = generator._road_length(distances) %}
-            {% set angles = generator._yaws(points) %}
-            <road name="{{model.name}}" length="{{total_length}}" id="{{segment_id}}">
+            {% set points = model.get_waypoint_positions() %}
+            {% set distances = model.get_waypoint_distances() %}
+            {% set angles = model.get_waypoints_yaws() %}
+            <road name="{{model.name}}" length="{{model.length()}}" id="{{segment_id}}">
               <type s="0.0000000000000000e+00" type="town"/>
               <planView>
-              {% for i in range(generator._collection_size(points) - 1)    %}
-                <geometry s="{{generator._road_length(distances[:i])}}" x="{{points[i].x}}" y="{{points[i].y}}" hdg="{{angles[i]}}" length="{{distances[i]}}">
+              {% for i in range(model.waypoints_count() - 1)    %}
+                <geometry s="{{model.length(0,i)}}" x="{{points[i].x}}" y="{{points[i].y}}" hdg="{{angles[i]}}" length="{{distances[i]}}">
                   <line/>
                 </geometry>
               {% endfor %}
@@ -100,35 +99,3 @@ class OpenDriveGenerator(FileGenerator):
 
     def trunk_template(self):
         return self.road_template()
-
-    def _distance(self, pA, pB):
-        return math.sqrt(math.pow(pA.x - pB.x, 2.0) + math.pow(pA.y - pB.y, 2.0))
-
-    def _road_length(self, distances):
-        return math.fsum(distances)
-
-    def _get_distances(self, points):
-        distances = []
-        for i in range(len(points) - 1):
-            distances.append(self._distance(points[i], points[i + 1]))
-        return distances
-
-    def _get_waypoint_positions(self, waypoints):
-        points = []
-        for waypoint in waypoints:
-            points.append(waypoint.center)
-        return points
-
-    def _collection_size(self, collection):
-        return len(collection)
-
-    def _yaw(self, pA, pB):
-        dX = pB.x - pA.x
-        dY = pB.y - pA.y
-        return math.atan2(dY, dX)
-
-    def _yaws(self, points):
-        yaws = []
-        for i in range(len(points) - 1):
-            yaws.append(self._yaw(points[i], points[i + 1]))
-        return yaws

--- a/terminus/generators/opendrive_generator.py
+++ b/terminus/generators/opendrive_generator.py
@@ -37,30 +37,29 @@ class OpenDriveGenerator(FileGenerator):
 
     def document_template(self):
         return """
-          <?xml version="1.0" standalone="yes"?>
+        <?xml version="1.0" standalone="yes"?>
           <OpenDRIVE xmlns="http://www.opendrive.org">
-          <header revMajor="1" revMinor="1" name="" version="1.00" north="0.0000000000000000e+00" south="0.0000000000000000e+00" east="0.0000000000000000e+00" west="0.0000000000000000e+00">
-          </header>
-          {{inner_contents}}
-          </OpenDRIVE>"""
+            <header revMajor="1" revMinor="1" name="" version="1.00" north="0.0000000000000000e+00" south="0.0000000000000000e+00" east="0.0000000000000000e+00" west="0.0000000000000000e+00">
+            </header>
+            {{inner_contents}}
+        </OpenDRIVE>"""
 
-    def road_template(self):
+    def street_template(self):
         return """
-        <road id={{road_id}} length="">
-            <type s="0.0000000000000000e+00" type="town"/>
-            <planView>
-            </planView>
-            <elevationProfile>
+            <road id={{road_id}} length="">
+              <type s="0.0000000000000000e+00" type="town"/>
+              <planView>
+              </planView>
+              <elevationProfile>
                 <elevation s="0.0000000000000000e+00" a="0.0000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
-            </elevationProfile>
-            <lateralProfile>
-            </lateralProfile>
-            <objects>
-            </objects>
-            <signals>
-            </signals>
-        </road>
-        """
+              </elevationProfile>
+              <lateralProfile>
+              </lateralProfile>
+              <objects>
+              </objects>
+              <signals>
+              </signals>
+            </road>"""
 
     def trunk_template(self):
-        return self.road_template()
+        return self.street_template()

--- a/terminus/generators/opendrive_generator.py
+++ b/terminus/generators/opendrive_generator.py
@@ -46,15 +46,30 @@ class OpenDriveGenerator(FileGenerator):
 
     def street_template(self):
         return """
-            <road id={{road_id}} length="">
+            <road name="" length="10.0" id="500">
               <type s="0.0000000000000000e+00" type="town"/>
               <planView>
+                  <geometry s="0.0000000000000000e+00" x="-7.0710678117841717e+00" y="7.0710678119660715e+00" hdg="5.4977871437752235e+00" length="10.0">
+                      <line/>
+                  </geometry>
               </planView>
               <elevationProfile>
-                <elevation s="0.0000000000000000e+00" a="0.0000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                  <elevation s="0.0000000000000000e+00" a="0.0000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
               </elevationProfile>
               <lateralProfile>
               </lateralProfile>
+              <lanes>
+                  <laneSection s="0.0000000000000000e+00">
+                      <center>
+                          <lane id="0" type="driving" level= "0">
+                              <link>
+                              </link>
+                              <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.3000000000000000e-01"/>
+                              <width sOffset="0.0000000000000000e+00" a="3.7500000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                          </lane>
+                      </center>
+                  </laneSection>
+              </lanes>
               <objects>
               </objects>
               <signals>

--- a/terminus/generators/opendrive_generator.py
+++ b/terminus/generators/opendrive_generator.py
@@ -70,10 +70,25 @@ class OpenDriveGenerator(FileGenerator):
                           <lane id="0" type="driving" level= "0">
                               <link>
                               </link>
-                              <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.3000000000000000e-01"/>
-                              <width sOffset="0.0000000000000000e+00" a="3.7500000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                              <roadMark sOffset="0.0000000000000000e+00" type="none" weight="standard" color="standard" width="1.3000000000000000e-01"/>
                           </lane>
                       </center>
+                      <left>
+                          <lane id="1" type="driving" level= "0">
+                              <link>
+                              </link>
+                              <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.3000000000000000e-01"/>
+                              <width sOffset="0.0000000000000000e+00" a="{{model.get_width()/2.0}}" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                          </lane>
+                      </left>
+                      <right>
+                          <lane id="-1" type="driving" level= "0">
+                              <link>
+                              </link>
+                              <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.3000000000000000e-01"/>
+                              <width sOffset="0.0000000000000000e+00" a="{{model.get_width()/2.0}}" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                          </lane>
+                      </right>
                   </laneSection>
               </lanes>
               <objects>

--- a/terminus/generators/opendrive_generator.py
+++ b/terminus/generators/opendrive_generator.py
@@ -1,0 +1,66 @@
+from file_generator import FileGenerator
+from geometry.point import Point
+from geometry.latlon import LatLon
+from city_visitor import CityVisitor
+from opendrive_id_mapper import OpenDriveIdMapper
+import math
+
+
+class OpenDriveGenerator(FileGenerator):
+
+    def __init__(self, city, origin):
+        super(OpenDriveGenerator, self).__init__(city)
+        self.origin = origin
+        self.id_mapper = OpenDriveIdMapper(city)
+
+    # # Start/End document handling
+    def start_document(self):
+        self.id_mapper.run()
+
+    def end_document(self):
+        print "Finishing doc"
+        self._wrap_document_with_template('document')
+
+    def start_street(self, street):
+        self.start_road(street)
+
+    def start_trunk(self, street):
+        self.start_road(street)
+
+    def start_road(self, road):
+        road_id = self.id_for(road)
+        road_content = self._contents_for(road, segment_id=road_id)
+        self._append_to_document(road_content)
+
+    def id_for(self, object):
+        return self.id_mapper.id_for(object)
+
+    def document_template(self):
+        return """
+          <?xml version="1.0" standalone="yes"?>
+          <OpenDRIVE xmlns="http://www.opendrive.org">
+          <header revMajor="1" revMinor="1" name="" version="1.00" north="0.0000000000000000e+00" south="0.0000000000000000e+00" east="0.0000000000000000e+00" west="0.0000000000000000e+00">
+          </header>
+          {{inner_contents}}
+          </OpenDRIVE>"""
+
+    def road_template(self):
+        return """
+        <road id={{road_id}} length="">
+            <type s="0.0000000000000000e+00" type="town"/>
+            <planView>
+            </planView>
+            <elevationProfile>
+                <elevation s="0.0000000000000000e+00" a="0.0000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+            </elevationProfile>
+            <lateralProfile>
+            </lateralProfile>
+            <objects>
+            </objects>
+            <signals>
+            </signals>
+        </road>
+        """
+
+    def trunk_template(self):
+        return self.road_template()

--- a/terminus/generators/opendrive_generator.py
+++ b/terminus/generators/opendrive_generator.py
@@ -17,9 +17,9 @@ class OpenDriveGenerator(FileGenerator):
     def start_document(self):
         self.id_mapper.run()
 
-    def end_document(self):
+    def end_city(self, city):
         print "Finishing doc"
-        self._wrap_document_with_template('document')
+        self._wrap_document_with_contents_for(city)
 
     def start_street(self, street):
         self.start_road(street)
@@ -35,11 +35,11 @@ class OpenDriveGenerator(FileGenerator):
     def id_for(self, object):
         return self.id_mapper.id_for(object)
 
-    def document_template(self):
+    def city_template(self):
         return """
         <?xml version="1.0" standalone="yes"?>
           <OpenDRIVE xmlns="http://www.opendrive.org">
-            <header revMajor="1" revMinor="1" name="" version="1.00" north="0.0000000000000000e+00" south="0.0000000000000000e+00" east="0.0000000000000000e+00" west="0.0000000000000000e+00" maxRoad="" maxJunc="0" maxPrg="0">
+            <header revMajor="1" revMinor="1" name="" version="1.00" north="0.0000000000000000e+00" south="0.0000000000000000e+00" east="0.0000000000000000e+00" west="0.0000000000000000e+00" maxRoad="{{model.roads_count()}}" maxJunc="0" maxPrg="0">
             </header>
             {{inner_contents}}
         </OpenDRIVE>"""
@@ -50,15 +50,14 @@ class OpenDriveGenerator(FileGenerator):
             {% set distances = generator._get_distances(points) %}
             {% set total_length = generator._road_length(distances) %}
             {% set angles = generator._yaws(points) %}
-            {% set last_distance = 0.0 %}
             <road name="{{model.name}}" length="{{total_length}}" id="{{segment_id}}">
               <type s="0.0000000000000000e+00" type="town"/>
               <planView>
               {% for i in range(generator._collection_size(points) - 1)    %}
                 <geometry s="{{generator._road_length(distances[:i])}}" x="{{points[i].x}}" y="{{points[i].y}}" hdg="{{angles[i]}}" length="{{distances[i]}}">
                   <line/>
+                </geometry>
               {% endfor %}
-                  </geometry>
               </planView>
               <elevationProfile>
                   <elevation s="0.0000000000000000e+00" a="0.0000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>

--- a/terminus/generators/opendrive_id_mapper.py
+++ b/terminus/generators/opendrive_id_mapper.py
@@ -1,0 +1,44 @@
+from city_visitor import CityVisitor
+
+
+class OpenDriveIdMapper(CityVisitor):
+
+    def run(self):
+        self.segment_id = 0
+        self.waypoint_id = 0
+        self.object_to_id_level_1 = {}
+        self.object_to_id_level_2 = {}
+        self.id_to_object = {}
+
+    def id_for(self, object):
+        self.segment_id = self.segment_id + 1
+        return self.segment_id
+        # try:
+        #     return self.object_to_id_level_1[id(object)]
+        # except KeyError:
+        #     return self.object_to_id_level_2[object]
+
+    def object_for(self, id):
+        return self.id_to_object[id]
+
+    def map_road(self, road):
+        self.segment_id = self.segment_id + 1
+        self.waypoint_id = 0
+        self._register(str(self.segment_id), road)
+        for waypoint in road.get_waypoints():
+            self.waypoint_id = self.waypoint_id + 1
+            rndf_id = str(self.segment_id) + '.1.' + str(self.waypoint_id)
+            self._register(rndf_id, waypoint)
+
+    def start_street(self, street):
+        self.map_road(street)
+
+    def start_trunk(self, trunk):
+        self.map_road(trunk)
+
+    def _register(self, rndf_id, object):
+        """We do some caching by id, to avoid computing hashes if they are
+        expensive, but keep the hash-based dict as a fallback"""
+        self.object_to_id_level_1[id(object)] = rndf_id
+        self.object_to_id_level_2[object] = rndf_id
+        self.id_to_object[rndf_id] = object

--- a/terminus/generators/opendrive_id_mapper.py
+++ b/terminus/generators/opendrive_id_mapper.py
@@ -5,40 +5,7 @@ class OpenDriveIdMapper(CityVisitor):
 
     def run(self):
         self.segment_id = 0
-        self.waypoint_id = 0
-        self.object_to_id_level_1 = {}
-        self.object_to_id_level_2 = {}
-        self.id_to_object = {}
 
     def id_for(self, object):
         self.segment_id = self.segment_id + 1
         return self.segment_id
-        # try:
-        #     return self.object_to_id_level_1[id(object)]
-        # except KeyError:
-        #     return self.object_to_id_level_2[object]
-
-    def object_for(self, id):
-        return self.id_to_object[id]
-
-    def map_road(self, road):
-        self.segment_id = self.segment_id + 1
-        self.waypoint_id = 0
-        self._register(str(self.segment_id), road)
-        for waypoint in road.get_waypoints():
-            self.waypoint_id = self.waypoint_id + 1
-            rndf_id = str(self.segment_id) + '.1.' + str(self.waypoint_id)
-            self._register(rndf_id, waypoint)
-
-    def start_street(self, street):
-        self.map_road(street)
-
-    def start_trunk(self, trunk):
-        self.map_road(trunk)
-
-    def _register(self, rndf_id, object):
-        """We do some caching by id, to avoid computing hashes if they are
-        expensive, but keep the hash-based dict as a fallback"""
-        self.object_to_id_level_1[id(object)] = rndf_id
-        self.object_to_id_level_2[object] = rndf_id
-        self.id_to_object[rndf_id] = object

--- a/terminus/generators/opendrive_id_mapper.py
+++ b/terminus/generators/opendrive_id_mapper.py
@@ -1,6 +1,10 @@
 from city_visitor import CityVisitor
 
 
+# This class is inteded to handle ids of junctions and roads.
+# All the ids should be unique, so this class will handle that, and the
+# reference to the objects it gives the new id. This class will have
+# development further.
 class OpenDriveIdMapper(CityVisitor):
 
     def run(self):

--- a/terminus/geometry/point.py
+++ b/terminus/geometry/point.py
@@ -58,11 +58,3 @@ class Point(object):
     def yaw(self, other):
         diff = other - self
         return math.atan2(diff.y, diff.x)
-
-    def roll(self, other):
-        diff = other - self
-        return math.atan2(diff.y, diff.z)
-
-    def pitch(self, other):
-        diff = other - self
-        return math.atan2(diff.x, diff.z)

--- a/terminus/geometry/point.py
+++ b/terminus/geometry/point.py
@@ -51,3 +51,18 @@ class Point(object):
             return Point(self.x / other, self.y / other, self.z / other)
         else:
             return Point(self.x / other.x, self.y / other.y, self.z / other.z)
+
+    def distance_to(self, other):
+        return math.sqrt(math.pow(self.x - other.x, 2.0) + math.pow(self.y - other.y, 2.0) + math.pow(self.z - other.z, 2.0))
+
+    def yaw(self, other):
+        diff = other - self
+        return math.atan2(diff.y, diff.x)
+
+    def roll(self, other):
+        diff = other - self
+        return math.atan2(diff.y, diff.z)
+
+    def pitch(self, other):
+        diff = other - self
+        return math.atan2(diff.x, diff.z)

--- a/terminus/models/road.py
+++ b/terminus/models/road.py
@@ -1,6 +1,7 @@
 from geometry.point import Point
 from shapely.geometry import LineString
 from city_model import CityModel
+import math
 
 
 class Road(CityModel):
@@ -90,6 +91,33 @@ class Road(CityModel):
 
     def be_two_way(self):
         pass
+
+    def length(self, initial=0, final=None):
+        distances = self.get_waypoint_distances()
+        if final is None:
+            return math.fsum(distances[initial:])
+        return math.fsum(distances[initial:final])
+
+    def get_waypoint_positions(self):
+        waypoints = self.get_waypoints()
+        points = []
+        for waypoint in waypoints:
+            points.append(waypoint.center)
+        return points
+
+    def get_waypoint_distances(self):
+        points = self.get_waypoint_positions()
+        distances = []
+        for i in range(len(points) - 1):
+            distances.append(points[i].distance_to(points[i + 1]))
+        return distances
+
+    def get_waypoints_yaws(self):
+        points = self.get_waypoint_positions()
+        yaws = []
+        for i in range(len(points) - 1):
+            yaws.append(points[i].yaw(points[i + 1]))
+        return yaws
 
     def _index_of_node_at(self, point):
         return next((index for index, node in enumerate(self.nodes) if node.center == point), None)

--- a/terminus/models/road.py
+++ b/terminus/models/road.py
@@ -103,17 +103,13 @@ class Road(CityModel):
 
     def get_waypoint_distances(self):
         points = self.get_waypoint_positions()
-        distances = []
-        for i in range(len(points) - 1):
-            distances.append(points[i].distance_to(points[i + 1]))
-        return distances
+        point_pairs = zip(points, points[1:])
+        return map(lambda point_pair: point_pair[0].distance_to(point_pair[1]), point_pairs)
 
     def get_waypoints_yaws(self):
         points = self.get_waypoint_positions()
-        yaws = []
-        for i in range(len(points) - 1):
-            yaws.append(points[i].yaw(points[i + 1]))
-        return yaws
+        point_pairs = zip(points, points[1:])
+        return map(lambda point_pair: point_pair[0].yaw(point_pair[1]), point_pairs)
 
     def _index_of_node_at(self, point):
         return next((index for index, node in enumerate(self.nodes) if node.center == point), None)

--- a/terminus/models/road.py
+++ b/terminus/models/road.py
@@ -99,11 +99,7 @@ class Road(CityModel):
         return math.fsum(distances[initial:final])
 
     def get_waypoint_positions(self):
-        waypoints = self.get_waypoints()
-        points = []
-        for waypoint in waypoints:
-            points.append(waypoint.center)
-        return points
+        return map(lambda waypoint: waypoint.center, self.get_waypoints())
 
     def get_waypoint_distances(self):
         points = self.get_waypoint_positions()

--- a/terminus/models/road.py
+++ b/terminus/models/road.py
@@ -103,11 +103,15 @@ class Road(CityModel):
 
     def get_waypoint_distances(self):
         points = self.get_waypoint_positions()
+        if len(points) == 1:
+            return [0.0]
         point_pairs = zip(points, points[1:])
         return map(lambda point_pair: point_pair[0].distance_to(point_pair[1]), point_pairs)
 
     def get_waypoints_yaws(self):
         points = self.get_waypoint_positions()
+        if len(points) == 1:
+            return [0.0]
         point_pairs = zip(points, points[1:])
         return map(lambda point_pair: point_pair[0].yaw(point_pair[1]), point_pairs)
 

--- a/terminus/run_generator.py
+++ b/terminus/run_generator.py
@@ -5,6 +5,7 @@ from generators.rndf_generator import RNDFGenerator
 from generators.sdf_generator_gazebo_7 import SDFGeneratorGazebo7
 from generators.sdf_generator_gazebo_8 import SDFGeneratorGazebo8
 from generators.street_plot_generator import StreetPlotGenerator
+from generators.opendrive_generator import OpenDriveGenerator
 from builders import *
 
 import argparse
@@ -58,6 +59,7 @@ destination_rndf_file = base_path + '.rndf'
 destination_sdf_7_file = base_path + '_gazebo_7.sdf'
 destination_sdf_8_file = base_path + '_gazebo_8.sdf'
 destination_street_plot_file = base_path + '_streets.png'
+destination_opendrive_file = base_path + '.xodr'
 
 # Get the class of the builder to use
 builder_class = getattr(sys.modules[__name__], arguments.builder)
@@ -100,3 +102,7 @@ if arguments.debug:
 logger.info("Generating RNDF file")
 rndf_generator = RNDFGenerator(city, RNDF_ORIGIN)
 rndf_generator.write_to(destination_rndf_file)
+
+logger.info("Generating OpenDrive file")
+opendrive_generator = OpenDriveGenerator(city, RNDF_ORIGIN)
+opendrive_generator.write_to(destination_opendrive_file)

--- a/terminus/tests/opendrive_generator_test.py
+++ b/terminus/tests/opendrive_generator_test.py
@@ -14,9 +14,6 @@ from generators.opendrive_generator import OpenDriveGenerator
 
 class OpenDriveGeneratorTest(unittest.TestCase):
 
-    def setUp(self):
-        pass
-
     def _get_sample_generator(self):
         city = City("Empty")
         latlon = LatLon(45.0, 45.0)
@@ -39,89 +36,3 @@ class OpenDriveGeneratorTest(unittest.TestCase):
     </header>
 
 </OpenDRIVE>""")
-
-    def test_distance(self):
-        generator = self._get_sample_generator()
-        pA = Point(1.0, 0.0)
-        pB = Point(-1.0, 0.0)
-        d = generator._distance(pA, pB)
-        self.assertEqual(d, 2.0)
-
-    def test_distances(self):
-        generator = self._get_sample_generator()
-        points = []
-        points.append(Point(-1.0, 0.0))
-        points.append(Point(0.0, 0.0))
-        points.append(Point(0.0, 1.0))
-
-        distances = generator._get_distances(points)
-        self.assertEqual(2, len(distances))
-        self.assertEqual(1.0, distances[0])
-        self.assertEqual(1.0, distances[1])
-
-    def test_road_legnth(self):
-        generator = self._get_sample_generator()
-        points = []
-        points.append(Point(-1.0, 0.0))
-        points.append(Point(0.0, 0.0))
-        points.append(Point(0.0, 1.0))
-
-        distances = generator._get_distances(points)
-        road_length = generator._road_length(distances)
-        self.assertEqual(2.0, road_length)
-        self.assertEqual(0.0, generator._road_length([]))
-
-    def test_yaw(self):
-        generator = self._get_sample_generator()
-        pA = Point(0.0, 0.0)
-        pB = Point(1.0, 0.0)
-
-        angle = generator._yaw(pA, pB)
-        self.assertEqual(0.0, angle)
-
-        pB = Point(1.0, 1.0)
-        angle = generator._yaw(pA, pB)
-        self.assertEqual(math.pi / 4.0, angle)
-
-        pB = Point(0.0, 1.0)
-        angle = generator._yaw(pA, pB)
-        self.assertEqual(math.pi / 2.0, angle)
-
-        pB = Point(-1.0, 1.0)
-        angle = generator._yaw(pA, pB)
-        self.assertEqual(3.0 * math.pi / 4.0, angle)
-
-        pB = Point(-1.0, 0.0)
-        angle = generator._yaw(pA, pB)
-        self.assertEqual(math.pi, angle)
-
-        pB = Point(-1.0, -1.0)
-        angle = generator._yaw(pA, pB)
-        self.assertEqual(- 3.0 * math.pi / 4.0, angle)
-
-        pB = Point(0.0, -1.0)
-        angle = generator._yaw(pA, pB)
-        self.assertEqual(- math.pi / 2.0, angle)
-
-        pB = Point(1.0, -1.0)
-        angle = generator._yaw(pA, pB)
-        self.assertEqual(- math.pi / 4.0, angle)
-
-    def test_yaws(self):
-        generator = self._get_sample_generator()
-        points = []
-        points.append(Point(0.0, 0.0))
-        points.append(Point(1.0, 1.0))
-        points.append(Point(2.0, 0.0))
-        points.append(Point(2.0, 1.0))
-
-        _angles = []
-        _angles.append(math.pi / 4.0)
-        _angles.append(-math.pi / 4.0)
-        _angles.append(math.pi / 2.0)
-
-        angles = generator._yaws(points)
-
-        self.assertEqual(len(_angles), len(angles))
-        for i in range(0, len(angles)):
-            self.assertEqual(_angles[i], angles[i])

--- a/terminus/tests/opendrive_generator_test.py
+++ b/terminus/tests/opendrive_generator_test.py
@@ -6,6 +6,7 @@ from models.city import City
 from models.road import *
 from models.street import Street
 from models.trunk import Trunk
+import math
 
 from generators.opendrive_generator import OpenDriveGenerator
 
@@ -38,3 +39,70 @@ class OpenDriveGeneratorTest(unittest.TestCase):
         self.assertEqual(2, len(distances))
         self.assertEqual(1.0, distances[0])
         self.assertEqual(1.0, distances[1])
+
+    def test_road_legnth(self):
+        generator = self._get_sample_generator()
+        points = []
+        points.append(Point(-1.0, 0.0))
+        points.append(Point(0.0, 0.0))
+        points.append(Point(0.0, 1.0))
+
+        distances = generator._get_distances(points)
+        road_length = generator._road_length(distances)
+        self.assertEqual(2.0, road_length)
+        self.assertEqual(0.0, generator._road_length([]))
+
+    def test_yaw(self):
+        generator = self._get_sample_generator()
+        pA = Point(0.0, 0.0)
+        pB = Point(1.0, 0.0)
+
+        angle = generator._yaw(pA, pB)
+        self.assertEqual(0.0, angle)
+
+        pB = Point(1.0, 1.0)
+        angle = generator._yaw(pA, pB)
+        self.assertEqual(math.pi / 4.0, angle)
+
+        pB = Point(0.0, 1.0)
+        angle = generator._yaw(pA, pB)
+        self.assertEqual(math.pi / 2.0, angle)
+
+        pB = Point(-1.0, 1.0)
+        angle = generator._yaw(pA, pB)
+        self.assertEqual(3.0 * math.pi / 4.0, angle)
+
+        pB = Point(-1.0, 0.0)
+        angle = generator._yaw(pA, pB)
+        self.assertEqual(math.pi, angle)
+
+        pB = Point(-1.0, -1.0)
+        angle = generator._yaw(pA, pB)
+        self.assertEqual(- 3.0 * math.pi / 4.0, angle)
+
+        pB = Point(0.0, -1.0)
+        angle = generator._yaw(pA, pB)
+        self.assertEqual(- math.pi / 2.0, angle)
+
+        pB = Point(1.0, -1.0)
+        angle = generator._yaw(pA, pB)
+        self.assertEqual(- math.pi / 4.0, angle)
+
+    def test_yaws(self):
+        generator = self._get_sample_generator()
+        points = []
+        points.append(Point(0.0, 0.0))
+        points.append(Point(1.0, 1.0))
+        points.append(Point(2.0, 0.0))
+        points.append(Point(2.0, 1.0))
+
+        _angles = []
+        _angles.append(math.pi / 4.0)
+        _angles.append(-math.pi / 4.0)
+        _angles.append(math.pi / 2.0)
+
+        angles = generator._yaws(points)
+
+        self.assertEqual(len(_angles), len(angles))
+        for i in range(0, len(angles)):
+            self.assertEqual(_angles[i], angles[i])

--- a/terminus/tests/opendrive_generator_test.py
+++ b/terminus/tests/opendrive_generator_test.py
@@ -7,6 +7,7 @@ from models.road import *
 from models.street import Street
 from models.trunk import Trunk
 import math
+import textwrap
 
 from generators.opendrive_generator import OpenDriveGenerator
 
@@ -20,6 +21,24 @@ class OpenDriveGeneratorTest(unittest.TestCase):
         city = City("Empty")
         latlon = LatLon(45.0, 45.0)
         return OpenDriveGenerator(city, latlon)
+
+    def _generate_output(self):
+        self.generated_contents = self.generator.generate()
+
+    def _assert_contents_are(self, expected_contents):
+        expected = textwrap.dedent(expected_contents)[1:]
+        self.assertMultiLineEqual(self.generated_contents, expected)
+
+    def test_empty_city(self):
+        self.generator = self._get_sample_generator()
+        self._generate_output()
+        self._assert_contents_are("""
+<?xml version="1.0" standalone="yes"?>
+  <OpenDRIVE xmlns="http://www.opendrive.org">
+    <header revMajor="1" revMinor="1" name="Empty" version="1.00" north="0.0000000000000000e+00" south="0.0000000000000000e+00" east="0.0000000000000000e+00" west="0.0000000000000000e+00" maxRoad="0" maxJunc="0" maxPrg="0">
+    </header>
+
+</OpenDRIVE>""")
 
     def test_distance(self):
         generator = self._get_sample_generator()

--- a/terminus/tests/opendrive_generator_test.py
+++ b/terminus/tests/opendrive_generator_test.py
@@ -1,0 +1,40 @@
+import unittest
+
+from geometry.point import Point
+from geometry.latlon import LatLon
+from models.city import City
+from models.road import *
+from models.street import Street
+from models.trunk import Trunk
+
+from generators.opendrive_generator import OpenDriveGenerator
+
+
+class OpenDriveGeneratorTest(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def _get_sample_generator(self):
+        city = City("Empty")
+        latlon = LatLon(45.0, 45.0)
+        return OpenDriveGenerator(city, latlon)
+
+    def test_distance(self):
+        generator = self._get_sample_generator()
+        pA = Point(1.0, 0.0)
+        pB = Point(-1.0, 0.0)
+        d = generator._distance(pA, pB)
+        self.assertEqual(d, 2.0)
+
+    def test_distances(self):
+        generator = self._get_sample_generator()
+        points = []
+        points.append(Point(-1.0, 0.0))
+        points.append(Point(0.0, 0.0))
+        points.append(Point(0.0, 1.0))
+
+        distances = generator._get_distances(points)
+        self.assertEqual(2, len(distances))
+        self.assertEqual(1.0, distances[0])
+        self.assertEqual(1.0, distances[1])

--- a/terminus/tests/opendrive_generator_test.py
+++ b/terminus/tests/opendrive_generator_test.py
@@ -27,12 +27,12 @@ class OpenDriveGeneratorTest(unittest.TestCase):
         self.assertMultiLineEqual(self.generated_contents, expected)
 
     def test_empty_city(self):
+        self.maxDiff = None
         self.generator = self._get_sample_generator()
         self._generate_output()
         self._assert_contents_are("""
-<?xml version="1.0" standalone="yes"?>
-  <OpenDRIVE xmlns="http://www.opendrive.org">
-    <header revMajor="1" revMinor="1" name="Empty" version="1.00" north="0.0000000000000000e+00" south="0.0000000000000000e+00" east="0.0000000000000000e+00" west="0.0000000000000000e+00" maxRoad="0" maxJunc="0" maxPrg="0">
-    </header>
-
-</OpenDRIVE>""")
+        <?xml version="1.0" standalone="yes"?>
+          <OpenDRIVE xmlns="http://www.opendrive.org">
+            <header revMajor="1" revMinor="1" name="Empty" version="1.00" north="0.0000000000000000e+00" south="0.0000000000000000e+00" east="0.0000000000000000e+00" west="0.0000000000000000e+00" maxRoad="0" maxJunc="0" maxPrg="0">
+            </header>\n
+        </OpenDRIVE>""")

--- a/terminus/tests/point_test.py
+++ b/terminus/tests/point_test.py
@@ -1,0 +1,54 @@
+import unittest
+import math
+from geometry.point import Point
+
+
+class PointTest(unittest.TestCase):
+
+    def test_distance_same_y(self):
+        p = Point(1.0, 0.0)
+        self.assertEqual(p.distance_to(Point(-1.0, 0.0)), 2.0)
+
+    def test_distance_same_x(self):
+        p = Point(0.0, 1.0)
+        self.assertEqual(p.distance_to(Point(0.0, -1.0)), 2.0)
+
+    def test_distance_conmutative(self):
+        p1 = Point(1.0, 1.0)
+        p2 = Point(-1.0, -1.0)
+        self.assertEqual(p1.distance_to(p2), p2.distance_to(p1))
+
+    def test_distance_same_point(self):
+        p = Point(1.0, 0.0)
+        self.assertEqual(p.distance_to(p), 0.0)
+
+    def test_distance_same_value_point(self):
+        p = Point(1.0, 0.0)
+        self.assertEqual(p.distance_to(Point(1.0, 0.0)), 0.0)
+
+    def test_yaw(self):
+        origin = Point(0.0, 0.0)
+
+        angle = origin.yaw(Point(1.0, 0.0))
+        self.assertEqual(0.0, angle)
+
+        angle = origin.yaw(Point(1.0, 1.0))
+        self.assertEqual(math.pi / 4.0, angle)
+
+        angle = origin.yaw(Point(0.0, 1.0))
+        self.assertEqual(math.pi / 2.0, angle)
+
+        angle = origin.yaw(Point(-1.0, 1.0))
+        self.assertEqual(3.0 * math.pi / 4.0, angle)
+
+        angle = origin.yaw(Point(-1.0, 0.0))
+        self.assertEqual(math.pi, angle)
+
+        angle = origin.yaw(Point(-1.0, -1.0))
+        self.assertEqual(- 3.0 * math.pi / 4.0, angle)
+
+        angle = origin.yaw(Point(0.0, -1.0))
+        self.assertEqual(- math.pi / 2.0, angle)
+
+        angle = origin.yaw(Point(1.0, -1.0))
+        self.assertEqual(- math.pi / 4.0, angle)

--- a/terminus/tests/road_test.py
+++ b/terminus/tests/road_test.py
@@ -13,19 +13,27 @@ class RoadTest(unittest.TestCase):
         road = Street.from_points([])
         self.assertEqual(road.get_waypoint_positions(), [])
 
-    def test_get_waypoint_positions(self):
+    def test_get_waypoint_positions_one_point(self):
         points = [Point(0.0, 1.0)]
         road = Street.from_points(points)
-        self.assertEqual(road.get_waypoint_positions(), [])
+        self.assertEqual(road.get_waypoint_positions(), points)
 
     def test_get_waypoint_positions(self):
         points = [Point(0.0, 1.0), Point(1.0, 1.0), Point(2.0, 1.0)]
         road = Street.from_points(points)
         self.assertEqual(road.get_waypoint_positions(), points)
 
+    def test_get_waypoint_distances_empty(self):
+        road = Street.from_points([])
+        self.assertEqual(road.get_waypoint_distances(), [])
+
+    def test_get_waypoint_distances_one_point(self):
+        road = Street.from_points([Point(1.0, 2.0)])
+        self.assertEqual(road.get_waypoint_distances(), [0.0])
+
     def test_get_waypoint_distances(self):
-        points = [Point(0.0, 1.0), Point(1.0, 1.0), Point(2.0, 1.0)]
-        distances = [1.0, 1.0]
+        points = [Point(0.0, 1.0), Point(1.0, 1.0), Point(2.0, 1.0), Point(0.0, 0.0)]
+        distances = [1.0, 1.0, math.sqrt(5)]
         road = Street.from_points(points)
         self.assertEqual(road.get_waypoint_distances(), distances)
 
@@ -35,22 +43,26 @@ class RoadTest(unittest.TestCase):
         road = Street.from_points(points)
         self.assertEqual(road.get_waypoints_yaws(), yaws)
 
-    def test_leght_full(self):
+    def test_length_full(self):
         points = [Point(0.0, 1.0), Point(1.0, 1.0), Point(2.0, 1.0)]
         road = Street.from_points(points)
         self.assertEqual(road.length(), 2.0)
 
-    def test_leght_partial_from_beginning(self):
+    def test_length_partial_from_beginning(self):
         points = [Point(0.0, 1.0), Point(1.0, 1.0), Point(2.0, 1.0)]
         road = Street.from_points(points)
         self.assertEqual(road.length(0, 1), 1.0)
 
-    def test_leght_partial_to_end(self):
+    def test_length_partial_to_end(self):
         points = [Point(0.0, 1.0), Point(1.0, 1.0), Point(2.0, 1.0)]
         road = Street.from_points(points)
         self.assertEqual(road.length(1), 1.0)
 
-    def test_leght_empty(self):
+    def test_length_empty(self):
         points = [Point(0.0, 1.0), Point(1.0, 1.0), Point(2.0, 1.0)]
         road = Street.from_points(points)
         self.assertEqual(road.length(1, 1), 0.0)
+
+    def test_length_empty_road(self):
+        road = Street.from_points([])
+        self.assertEqual(road.length(), 0.0)

--- a/terminus/tests/road_test.py
+++ b/terminus/tests/road_test.py
@@ -9,6 +9,15 @@ import math
 
 class RoadTest(unittest.TestCase):
 
+    def test_get_waypoint_positions_empty(self):
+        road = Street.from_points([])
+        self.assertEqual(road.get_waypoint_positions(), [])
+
+    def test_get_waypoint_positions(self):
+        points = [Point(0.0, 1.0)]
+        road = Street.from_points(points)
+        self.assertEqual(road.get_waypoint_positions(), [])
+
     def test_get_waypoint_positions(self):
         points = [Point(0.0, 1.0), Point(1.0, 1.0), Point(2.0, 1.0)]
         road = Street.from_points(points)

--- a/terminus/tests/road_test.py
+++ b/terminus/tests/road_test.py
@@ -1,0 +1,47 @@
+import unittest
+
+from geometry.point import Point
+from geometry.latlon import LatLon
+from models.road import Road
+from models.street import Street
+import math
+
+
+class RoadTest(unittest.TestCase):
+
+    def test_get_waypoint_positions(self):
+        points = [Point(0.0, 1.0), Point(1.0, 1.0), Point(2.0, 1.0)]
+        road = Street.from_points(points)
+        self.assertEqual(road.get_waypoint_positions(), points)
+
+    def test_get_waypoint_distances(self):
+        points = [Point(0.0, 1.0), Point(1.0, 1.0), Point(2.0, 1.0)]
+        distances = [1.0, 1.0]
+        road = Street.from_points(points)
+        self.assertEqual(road.get_waypoint_distances(), distances)
+
+    def test_get_waypoints_yaws(self):
+        points = [Point(0.0, 0.0), Point(1.0, 1.0), Point(2.0, 1.0)]
+        yaws = [math.pi / 4.0, 0.0]
+        road = Street.from_points(points)
+        self.assertEqual(road.get_waypoints_yaws(), yaws)
+
+    def test_leght_full(self):
+        points = [Point(0.0, 1.0), Point(1.0, 1.0), Point(2.0, 1.0)]
+        road = Street.from_points(points)
+        self.assertEqual(road.length(), 2.0)
+
+    def test_leght_partial_from_beginning(self):
+        points = [Point(0.0, 1.0), Point(1.0, 1.0), Point(2.0, 1.0)]
+        road = Street.from_points(points)
+        self.assertEqual(road.length(0, 1), 1.0)
+
+    def test_leght_partial_to_end(self):
+        points = [Point(0.0, 1.0), Point(1.0, 1.0), Point(2.0, 1.0)]
+        road = Street.from_points(points)
+        self.assertEqual(road.length(1), 1.0)
+
+    def test_leght_empty(self):
+        points = [Point(0.0, 1.0), Point(1.0, 1.0), Point(2.0, 1.0)]
+        road = Street.from_points(points)
+        self.assertEqual(road.length(1, 1), 0.0)


### PR DESCRIPTION
@basicNew this is a first version of the OpenDrive generator. It includes only lines to generate the roads, with two lanes each, one to the left and the other to the right of the base lane. This base line is 0 meter thick, and the other two has a half of the road width value.
Here are some sample pictures of the outputs

![city-1500](https://cloud.githubusercontent.com/assets/3825465/22066470/dcd6afa2-dd6b-11e6-98b5-96b3e443f25f.png)

![city-10kmsq](https://cloud.githubusercontent.com/assets/3825465/22066475/e1fbdc64-dd6b-11e6-971c-3eaa7194d262.png)

![city-10kmsq2](https://cloud.githubusercontent.com/assets/3825465/22066484/e6efcb7c-dd6b-11e6-95c2-748bacd1fb3d.png)


Also, I have included tests for the calculations made for creating the file. I consider those calculations won't change in a while as well as the empty map.
 
The visualization tool can be found [here](http://www.opendrive.org/download.html)

closes #149


