### PR TITLE
Issue/#157 junction support to the open drive generator

### DIFF
--- a/terminus/generators/opendrive_generator.py
+++ b/terminus/generators/opendrive_generator.py
@@ -28,20 +28,15 @@ class OpenDriveGenerator(FileGenerator):
         self.start_road(street)
 
     def start_road(self, road):
-        road_id = self.id_for(road)
-        road_content = self._contents_for(road, segment_id=road_id)
-        self._append_to_document(road_content)
-
-    def id_for(self, object):
-        return self.id_mapper.id_for(object)
+        pass
 
     def city_template(self):
         return """
         <?xml version="1.0" standalone="yes"?>
           <OpenDRIVE xmlns="http://www.opendrive.org">
-            <header revMajor="1" revMinor="1" name="{{model.name}}" version="1.00" north="0.0000000000000000e+00" south="0.0000000000000000e+00" east="0.0000000000000000e+00" west="0.0000000000000000e+00" maxRoad="{{generator.get_last_road_id()}}" maxJunc="0" maxPrg="0">
+            <header revMajor="1" revMinor="1" name="{{model.name}}" version="1.00" north="0.0000000000000000e+00" south="0.0000000000000000e+00" east="0.0000000000000000e+00" west="0.0000000000000000e+00" maxRoad="{{generator.get_last_road_id()}}" maxJunc="{{generator.get_last_junction_id()}}" maxPrg="0">
             </header>
-            {% for road in generator.id_mapper.roads %}
+            {% for road in generator.get_roads() %}
             {%     set points = road.get_waypoint_positions() %}
             {%     set distances = road.get_waypoint_distances() %}
             {%     set angles = road.get_waypoints_yaws() %}
@@ -73,7 +68,7 @@ class OpenDriveGenerator(FileGenerator):
                               <link>
                               </link>
                               <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.3000000000000000e-01"/>
-                              <width sOffset="0.0000000000000000e+00" a="{{road.get_width()}}" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                              <width sOffset="0.0000000000000000e+00" a="{{1.0}}" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
                           </lane>
                       </right>
                   </laneSection>
@@ -83,6 +78,10 @@ class OpenDriveGenerator(FileGenerator):
               <signals>
               </signals>
             </road>
+            {% endfor %}
+            {% for junction in generator.get_junction() %}
+              <junction name="" id="{{junction.id}}">
+              </junction>
             {% endfor %}
         </OpenDRIVE>"""
 
@@ -98,11 +97,14 @@ class OpenDriveGenerator(FileGenerator):
     def trunk_template(self):
         return self.road_template()
 
-    def get_last_junction_id(self):
-        if self.id_mapper.junctions:
-            junction = self.id_mapper.junctions[-1]
-            return junction.id
-        return 0
-
     def get_last_road_id(self):
-        return self.id_mapper.get_current_id()
+        return self.id_mapper.road_id_max
+
+    def get_last_junction_id(self):
+        return self.id_mapper.junction_id_max
+
+    def get_roads(self):
+        return self.id_mapper.get_od_roads_as_list()
+
+    def get_junction(self):
+        return self.id_mapper.junctions

--- a/terminus/generators/opendrive_generator.py
+++ b/terminus/generators/opendrive_generator.py
@@ -42,6 +42,14 @@ class OpenDriveGenerator(FileGenerator):
             {%     set angles = road.get_waypoints_yaws() %}
             <road name="{{road.name}}" length="{{road.length()}}" id="{{road.id}}">
               <type s="0.0000000000000000e+00" type="town"/>
+              <link>
+            {%     if road.predecessor: %}
+                <predecessor elementType="{{road.predecessor_type}}" elementId="{{road.predecessor}}" contactPoint="start" />
+            {%     endif %}
+            {%     if road.successor: %}
+                <successor elementType="{{road.successor_type}}" elementId="{{road.successor}}" contactPoint="end" />
+            {%     endif %}
+              </link>
               <planView>
               {% for i in range(road.waypoints_count() - 1)    %}
                 <geometry s="{{road.length(0,i)}}" x="{{points[i].x}}" y="{{points[i].y}}" hdg="{{angles[i]}}" length="{{distances[i]}}">

--- a/terminus/generators/opendrive_generator.py
+++ b/terminus/generators/opendrive_generator.py
@@ -76,7 +76,7 @@ class OpenDriveGenerator(FileGenerator):
                               <link>
                               </link>
                               <roadMark sOffset="0.0" type="solid" weight="standard" color="standard" width="1.3e-01"/>
-                              <width sOffset="0.0" a="{{1.0}}" b="0.0" c="0.0" d="0.0"/>
+                              <width sOffset="0.0" a="{{road.width}}" b="0.0" c="0.0" d="0.0"/>
                           </lane>
                       </right>
                   </laneSection>

--- a/terminus/generators/opendrive_generator.py
+++ b/terminus/generators/opendrive_generator.py
@@ -34,17 +34,17 @@ class OpenDriveGenerator(FileGenerator):
         return """
         <?xml version="1.0" standalone="yes"?>
           <OpenDRIVE xmlns="http://www.opendrive.org">
-            <header revMajor="1" revMinor="1" name="{{model.name}}" version="1.00" north="0.0000000000000000e+00" south="0.0000000000000000e+00" east="0.0000000000000000e+00" west="0.0000000000000000e+00" maxRoad="{{generator.get_last_road_id()}}" maxJunc="{{generator.get_last_junction_id()}}" maxPrg="0">
+            <header revMajor="1" revMinor="1" name="{{model.name}}" version="1.00" north="0.0" south="0.0" east="0.0" west="0.0" maxRoad="{{generator.get_last_road_id()}}" maxJunc="{{generator.get_last_junction_id()}}" maxPrg="0">
             </header>
             {% for road in generator.get_roads() %}
             {%     set points = road.get_waypoint_positions() %}
             {%     set distances = road.get_waypoint_distances() %}
             {%     set angles = road.get_waypoints_yaws() %}
             <road name="{{road.name}}" length="{{road.length()}}" id="{{road.id}}">
-              <type s="0.0000000000000000e+00" type="town"/>
+              <type s="0.0" type="town" junction="{{road.junction_id}}"/>
               <link>
             {%     if road.predecessor: %}
-                <predecessor elementType="{{road.predecessor_type}}" elementId="{{road.predecessor}}" contactPoint="start" />
+                <predecessor elementType="{{road.predecessor_type}}" elementId="{{road.predecessor}}" {% if road.predecessor_type != 'junction': %}contactPoint="start"{% endif %} />
             {%     endif %}
             {%     if road.successor: %}
                 <successor elementType="{{road.successor_type}}" elementId="{{road.successor}}" contactPoint="end" />
@@ -58,25 +58,25 @@ class OpenDriveGenerator(FileGenerator):
               {% endfor %}
               </planView>
               <elevationProfile>
-                  <elevation s="0.0000000000000000e+00" a="0.0000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                  <elevation s="0.0e+00" a="0.0" b="0.0" c="0.0" d="0.0"/>
               </elevationProfile>
               <lateralProfile>
               </lateralProfile>
               <lanes>
-                  <laneSection s="0.0000000000000000e+00">
+                  <laneSection s="0.0">
                       <center>
                           <lane id="0" type="driving" level= "0">
                               <link>
                               </link>
-                              <roadMark sOffset="0.0000000000000000e+00" type="none" weight="standard" color="standard" width="1.3000000000000000e-01"/>
+                              <roadMark sOffset="0.0" type="none" weight="standard" color="standard" width="1.3e-01"/>
                           </lane>
                       </center>
                       <right>
                           <lane id="-1" type="driving" level= "0">
                               <link>
                               </link>
-                              <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.3000000000000000e-01"/>
-                              <width sOffset="0.0000000000000000e+00" a="{{1.0}}" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                              <roadMark sOffset="0.0" type="solid" weight="standard" color="standard" width="1.3e-01"/>
+                              <width sOffset="0.0" a="{{1.0}}" b="0.0" c="0.0" d="0.0"/>
                           </lane>
                       </right>
                   </laneSection>
@@ -87,8 +87,13 @@ class OpenDriveGenerator(FileGenerator):
               </signals>
             </road>
             {% endfor %}
-            {% for junction in generator.get_junction() %}
+            {% for junction in generator.get_junctions() %}
               <junction name="" id="{{junction.id}}">
+            {%     for i in range(0, generator.get_junction_link_count(junction)) %}
+                <connection id="{{i}}" incomingRoad="{{junction.links[i].incomming_road}}" connectingRoad="{{junction.links[i].connecting_road}}" contactPoint="start">
+                  <laneLink from="1" to="1"/>
+                </connection>
+            {%     endfor %}
               </junction>
             {% endfor %}
         </OpenDRIVE>"""
@@ -114,5 +119,8 @@ class OpenDriveGenerator(FileGenerator):
     def get_roads(self):
         return self.id_mapper.get_od_roads_as_list()
 
-    def get_junction(self):
+    def get_junctions(self):
         return self.id_mapper.junctions
+
+    def get_junction_link_count(self, junction):
+        return len(junction.links)

--- a/terminus/generators/opendrive_id_mapper.py
+++ b/terminus/generators/opendrive_id_mapper.py
@@ -1,5 +1,6 @@
 from city_visitor import CityVisitor
 from models.road import Road
+import operator
 
 
 # This class is inteded to handle ids of junctions and roads.
@@ -14,24 +15,25 @@ class OpenDriveIdMapper(CityVisitor):
 
     def run(self):
         self.id_counter = 0
-        self.roads_to_id = {}
-        self.roads = []
+        self.junction_id_max = 0
+        self.road_id_max = 0
+        self.od_roads = {}
         self.junctions = []
         self.create_junctions()
         self.create_roads()
 
-    def get_new_id(self):
+    def get_new_road_id(self):
         self.id_counter = self.id_counter + 1
+        self.road_id_max = self.id_counter
+        return self.id_counter
+
+    def get_new_junction_id(self):
+        self.id_counter = self.id_counter + 1
+        self.junction_id_max = self.id_counter
         return self.id_counter
 
     def get_current_id(self):
         return self.id_counter
-
-    def id_for(self, road):
-        road_hash = hash(road)
-        if road_hash in self.roads_to_id:
-            return self.roads_to_id[road_hash]
-        return None
 
     def create_junctions(self):
         entry_exits = self.create_connections()
@@ -44,7 +46,7 @@ class OpenDriveIdMapper(CityVisitor):
             if _junctions:
                 _junction = _junctions[0]
             else:
-                _junction = Junction(self.get_new_id())
+                _junction = Junction(self.get_new_junction_id())
                 self.junctions.append(_junction)
             _junction.add_connection(entry_exit)
 
@@ -59,24 +61,79 @@ class OpenDriveIdMapper(CityVisitor):
         return connections
 
     def create_roads(self):
-        self.roads = []
-        for road in self.city.roads:
-            cutting_waypoint_ids = self.get_cutting_waypoints(road)
-            cut_roads = self.cut_road(road, cutting_waypoint_ids)
-            self.roads.extend(cut_roads)
+        # Create road cuts from the original roads and insert them
+        # into the map
+        self.create_road_cuts()
+        # Create the roads from the connections. Then, create a link
+        # between the road cut and the connection
+        self.create_junction_roads()
+
+    def get_od_roads_as_list(self):
+        od_roads = self.od_roads.items()
+        if not od_roads:
+            return []
+        hashes, roads = zip(*od_roads)
+        return reduce(operator.add, roads)
+
+    def get_road_cut(self, road_hash, waypoint):
+        roads = self.od_roads[road_hash]
+        road_cuts = filter(lambda road: self.road_cut_contains_waypoint(road, waypoint), roads)
+        if not road_cuts:
+            return None
+        if waypoint.is_entry and len(road_cuts) == 2:
+            return road_cuts[1]
+        return road_cuts[0]
+
+    def create_junction_roads(self):
         for junction in self.junctions:
-            self.roads.extend(
-                map(lambda conn:
-                    self.create_road_from_connection(conn),
-                    junction.connections))
-        for road in self.roads:
-            road.id = self.get_new_id()
+            for conn in junction.connections:
+                road = self.create_road_from_connection(conn)
+                road.id = self.get_new_road_id()
+                (entry_hash, exit_hash) = conn.get_road_hashes()
+                entry_road_cut = self.get_road_cut(entry_hash, conn.entry)
+                exit_road_cut = self.get_road_cut(exit_hash, conn.exit)
+                if entry_road_cut is not None:
+                    entry_road_cut.junction_id = junction.id
+                    entry_road_cut.sucessor = junction.id
+                    entry_road_cut.sucessor_type = "junction"
+                    road.predecessor = entry_road_cut.id
+                    road.predecessor_type = "road"
+                if exit_road_cut is not None:
+                    exit_road_cut.junction_id = junction.id
+                    exit_road_cut.predecessor = junction.id
+                    exit_road_cut.predecessor_type = "junction"
+                    road.sucessor = exit_road_cut.id
+                    road.sucessor_type = "road"
+                self.od_roads[hash(road)] = [road]
+
+    def road_cut_contains_waypoint(self, road_cut, waypoint):
+        wps = filter(lambda wp: wp.center == waypoint.center, road_cut.get_waypoints())
+        return not wps
 
     def cut_road(self, road, cutting_waypoint_ids):
         cut_roads = []
         for i in range(0, len(cutting_waypoint_ids) - 1):
-            cut_roads.append(OpenDriveRoad.from_base_road(road, cutting_waypoint_ids[i], cutting_waypoint_ids[i + 1]))
+            cut_road = OpenDriveRoad.from_base_road(road, cutting_waypoint_ids[i][0], cutting_waypoint_ids[i + 1][0])
+            cut_road.id = self.get_new_road_id()
+            if cutting_waypoint_ids[i][1] is 'exit' or cutting_waypoint_ids[i][1] is 'entry':
+                cut_road.predecessor = cut_roads[-1].id
+                cut_road.predecessor_type = 'road'
+                cut_roads[-1].sucessor = cut_road.id
+                cut_roads[-1].sucessor_type = 'road'
+            cut_roads.append(cut_road)
+        if cutting_waypoint_ids[-2][1] is 'exit' or cutting_waypoint_ids[-2][1] is 'entry':
+            cut_roads[-1].predecessor = cut_roads[-2].id
+            cut_roads[-1].predecessor_type = 'road'
+            cut_roads[-2].sucessor = cut_roads[-1].id
+            cut_roads[-2].sucessor_type = 'road'
         return cut_roads
+
+    def create_road_cuts(self):
+        for road in self.city.roads:
+            road_hash = hash(road)
+            cutting_waypoint_ids = self.get_cutting_waypoints(road)
+            cut_roads = self.cut_road(road, cutting_waypoint_ids)
+            self.od_roads[road_hash] = cut_roads
 
     def create_road_from_connection(self, connection):
         width = min(connection.entry.road.width, connection.exit.road.width)
@@ -85,11 +142,16 @@ class OpenDriveIdMapper(CityVisitor):
         road.add_point(connection.entry.center)
         return road
 
-    def _cut_road_condition(self, waypoint, waypoints):
-        return (waypoint.is_exit() or
-                waypoint.is_entry() or
-                waypoint == waypoints[-1] or
-                waypoint == waypoints[0])
+    def waypoint_type(self, waypoint, waypoints):
+        if waypoint == waypoints[0]:
+            return 'start'
+        if waypoint == waypoints[-1]:
+            return 'end'
+        if waypoint.is_entry():
+            return 'entry'
+        if waypoint.is_exit():
+            return 'exit'
+        return 'other'
 
     def get_cutting_waypoints(self, road):
         waypoints = road.get_waypoints()
@@ -97,14 +159,15 @@ class OpenDriveIdMapper(CityVisitor):
         # is the current road in the iteration
         connection_waypoints_ids = map(
             lambda waypoint:
-                waypoints.index(waypoint) if self._cut_road_condition(waypoint, waypoints) else None,
+                waypoints.index(waypoint) if self.waypoint_type(waypoint, waypoints) != 'other' else None,
             road.get_waypoints())
         connection_waypoints_ids = filter(lambda id: id is not None, connection_waypoints_ids)
-        return connection_waypoints_ids
 
-    def map_roads(self):
-        for road in self.city.roads:
-            self.roads_to_id[hash(road)] = self.get_new_id()
+        waypoint_types = []
+        for id in connection_waypoints_ids:
+            waypoint_types.append(self.waypoint_type(waypoints[id], waypoints))
+
+        return zip(connection_waypoints_ids, waypoint_types)
 
 
 class OpenDriveRoad(Road):
@@ -112,8 +175,11 @@ class OpenDriveRoad(Road):
     def __init__(self, width, name=None, id=None):
         super(OpenDriveRoad, self).__init__(width, name)
         self.id = id
+        self.junction_id = None
         self.predecessor = None
+        self.predecessor_type = None
         self.sucessor = None
+        self.sucessor_type = None
 
     @classmethod
     def from_base_road(cls, road, initPoint, endPoint):
@@ -128,7 +194,7 @@ class OpenDriveRoad(Road):
             self.add_point(point)
 
 
-class Junction:
+class Junction(object):
 
     def __init__(self, _id):
         self.connections = []
@@ -165,11 +231,14 @@ class Junction:
         return road_hash in self.roads
 
 
-class Connection:
+class Connection(object):
 
     def __init__(self, _exit, _entry):
         self.entry = _entry
         self.exit = _exit
+
+    def get_road_hashes(self):
+        return (hash(self.entry.road), hash(self.exit.road))
 
     def __str__(self):
         return 'entry_' + str(hash(self.entry)) + '_exit_' + str(hash(self.exit))

--- a/terminus/generators/opendrive_id_mapper.py
+++ b/terminus/generators/opendrive_id_mapper.py
@@ -1,7 +1,5 @@
 from city_visitor import CityVisitor
 
-import logging
-
 
 # This class is inteded to handle ids of junctions and roads.
 # All the ids should be unique, so this class will handle that, and the
@@ -13,66 +11,85 @@ class OpenDriveIdMapper(CityVisitor):
         super(OpenDriveIdMapper, self).__init__(city)
 
     def run(self):
-        self.id = 0
-        self.segment_id = 0
-        # self.create_junctions()
-        # for junction in junctions:
-        #    logger.info(junction)
-
-    def id_for(self, object):
-        self.segment_id = self.segment_id + 1
-        return self.segment_id
+        self.id_counter = 0
+        self.roads_to_id = {}
+        self.create_junctions()
+        self.map_roads()
 
     def get_new_id(self):
-        self.id = self.id + 1
-        return self.id
+        self.id_counter = self.id_counter + 1
+        return self.id_counter
+
+    def id_for(self, road):
+        road_hash = hash(road)
+        if road_hash in self.roads_to_id:
+            return self.roads_to_id[road_hash]
+        return None
 
     def create_junctions(self):
         entry_exits = self.create_extryexits()
         self.junctions = []
         for entry_exit in entry_exits:
-            _junction = filter(
+            _junctions = filter(
                 lambda junction:
                     junction.contains_waypoint(entry_exit.entry) or junction.contains_waypoint(entry_exit.exit),
-                junctions)
-            if _junction is None:
+                self.junctions)
+            if _junctions:
+                _junction = _junctions[0]
+            else:
                 _junction = Junction(self.get_new_id())
-                self.junction.append(_junction)
-            _junction.append(entry_exit.entry)
-            _junction.append(entry_exit.exit)
+                self.junctions.append(_junction)
+            _junction.add_connection(entry_exit)
 
     def create_extryexits(self):
-        entry_exits = []
+        connections = []
         for road in self.city.roads:
             exit_waypoints = filter(lambda waypoint: waypoint.is_exit(), road.get_waypoints())
             waypoint_connections = []
             for exit_waypoint in exit_waypoints:
                 for entry_waypoint in exit_waypoint.connected_waypoints():
-                    entry_exit = EntryExit(exit_waypoint, entry_waypoint)
-                    entry_exits.append(entry_exit)
+                    connection = Connection(exit_waypoint, entry_waypoint)
+                    connections.append(connection)
+        return connections
+
+    def map_roads(self):
+        for road in self.city.roads:
+            self.roads_to_id[hash(road)] = self.get_new_id()
 
 
 class Junction:
 
     def __init__(self, _id):
-        self.waypoints = {}
+        self.connections = []
         self.id = _id
 
-    def add_waypoint(self, waypoint):
-        self.waypoints[hash(waypoint)] = waypoint
+    def add_connection(self, connection):
+        self.connections.append(connection)
 
     def contains_waypoint(self, waypoint):
-        return self.waypoints[hash(waypoint)] is not None
+        connections = filter(
+            lambda conn:
+                conn.entry == waypoint or conn.exit == waypoint,
+            self.connections)
+        if connections:
+            return True
+        return False
+
+    def connection_size(self):
+        return len(self.connections)
 
     def __str__(self):
         hashes = ''
-        for waypoint in enumerate(self.waypoints):
-            hashes = hashes + ' | ' + hash(waypoint)
+        for connection in self.connections:
+            hashes = hashes + '_' + str(connection)
         return "junction: " + hashes
 
 
-class EntryExit:
+class Connection:
 
     def __init__(self, _exit, _entry):
         self.entry = _entry
         self.exit = _exit
+
+    def __str__(self):
+        return 'entry_' + str(hash(self.entry)) + '_exit_' + str(hash(self.exit))

--- a/terminus/generators/opendrive_id_mapper.py
+++ b/terminus/generators/opendrive_id_mapper.py
@@ -94,16 +94,16 @@ class OpenDriveIdMapper(CityVisitor):
                 exit_road_cut = self.get_road_cut(exit_hash, conn.exit)
                 if entry_road_cut is not None:
                     entry_road_cut.junction_id = junction.id
-                    entry_road_cut.sucessor = junction.id
-                    entry_road_cut.sucessor_type = "junction"
+                    entry_road_cut.successor = junction.id
+                    entry_road_cut.successor_type = "junction"
                     road.predecessor = entry_road_cut.id
                     road.predecessor_type = "road"
                 if exit_road_cut is not None:
                     exit_road_cut.junction_id = junction.id
                     exit_road_cut.predecessor = junction.id
                     exit_road_cut.predecessor_type = "junction"
-                    road.sucessor = exit_road_cut.id
-                    road.sucessor_type = "road"
+                    road.successor = exit_road_cut.id
+                    road.successor_type = "road"
                 self.od_roads[hash(road)] = [road]
 
     def road_cut_contains_waypoint(self, road_cut, waypoint):
@@ -118,14 +118,14 @@ class OpenDriveIdMapper(CityVisitor):
             if cutting_waypoint_ids[i][1] is 'exit' or cutting_waypoint_ids[i][1] is 'entry':
                 cut_road.predecessor = cut_roads[-1].id
                 cut_road.predecessor_type = 'road'
-                cut_roads[-1].sucessor = cut_road.id
-                cut_roads[-1].sucessor_type = 'road'
+                cut_roads[-1].successor = cut_road.id
+                cut_roads[-1].successor_type = 'road'
             cut_roads.append(cut_road)
         if cutting_waypoint_ids[-2][1] is 'exit' or cutting_waypoint_ids[-2][1] is 'entry':
             cut_roads[-1].predecessor = cut_roads[-2].id
             cut_roads[-1].predecessor_type = 'road'
-            cut_roads[-2].sucessor = cut_roads[-1].id
-            cut_roads[-2].sucessor_type = 'road'
+            cut_roads[-2].successor = cut_roads[-1].id
+            cut_roads[-2].successor_type = 'road'
         return cut_roads
 
     def create_road_cuts(self):
@@ -178,8 +178,8 @@ class OpenDriveRoad(Road):
         self.junction_id = None
         self.predecessor = None
         self.predecessor_type = None
-        self.sucessor = None
-        self.sucessor_type = None
+        self.successor = None
+        self.successor_type = None
 
     @classmethod
     def from_base_road(cls, road, initPoint, endPoint):

--- a/terminus/generators/opendrive_id_mapper.py
+++ b/terminus/generators/opendrive_id_mapper.py
@@ -1,5 +1,7 @@
 from city_visitor import CityVisitor
 
+import logging
+
 
 # This class is inteded to handle ids of junctions and roads.
 # All the ids should be unique, so this class will handle that, and the
@@ -7,9 +9,70 @@ from city_visitor import CityVisitor
 # development further.
 class OpenDriveIdMapper(CityVisitor):
 
+    def __init__(self, city):
+        super(OpenDriveIdMapper, self).__init__(city)
+
     def run(self):
+        self.id = 0
         self.segment_id = 0
+        # self.create_junctions()
+        # for junction in junctions:
+        #    logger.info(junction)
 
     def id_for(self, object):
         self.segment_id = self.segment_id + 1
         return self.segment_id
+
+    def get_new_id(self):
+        self.id = self.id + 1
+        return self.id
+
+    def create_junctions(self):
+        entry_exits = self.create_extryexits()
+        self.junctions = []
+        for entry_exit in entry_exits:
+            _junction = filter(
+                lambda junction:
+                    junction.contains_waypoint(entry_exit.entry) or junction.contains_waypoint(entry_exit.exit),
+                junctions)
+            if _junction is None:
+                _junction = Junction(self.get_new_id())
+                self.junction.append(_junction)
+            _junction.append(entry_exit.entry)
+            _junction.append(entry_exit.exit)
+
+    def create_extryexits(self):
+        entry_exits = []
+        for road in self.city.roads:
+            exit_waypoints = filter(lambda waypoint: waypoint.is_exit(), road.get_waypoints())
+            waypoint_connections = []
+            for exit_waypoint in exit_waypoints:
+                for entry_waypoint in exit_waypoint.connected_waypoints():
+                    entry_exit = EntryExit(exit_waypoint, entry_waypoint)
+                    entry_exits.append(entry_exit)
+
+
+class Junction:
+
+    def __init__(self, _id):
+        self.waypoints = {}
+        self.id = _id
+
+    def add_waypoint(self, waypoint):
+        self.waypoints[hash(waypoint)] = waypoint
+
+    def contains_waypoint(self, waypoint):
+        return self.waypoints[hash(waypoint)] is not None
+
+    def __str__(self):
+        hashes = ''
+        for waypoint in enumerate(self.waypoints):
+            hashes = hashes + ' | ' + hash(waypoint)
+        return "junction: " + hashes
+
+
+class EntryExit:
+
+    def __init__(self, _exit, _entry):
+        self.entry = _entry
+        self.exit = _exit

--- a/terminus/tests/opendrive_generator_test.py
+++ b/terminus/tests/opendrive_generator_test.py
@@ -33,6 +33,6 @@ class OpenDriveGeneratorTest(unittest.TestCase):
         self._assert_contents_are("""
         <?xml version="1.0" standalone="yes"?>
           <OpenDRIVE xmlns="http://www.opendrive.org">
-            <header revMajor="1" revMinor="1" name="Empty" version="1.00" north="0.0000000000000000e+00" south="0.0000000000000000e+00" east="0.0000000000000000e+00" west="0.0000000000000000e+00" maxRoad="0" maxJunc="0" maxPrg="0">
+            <header revMajor="1" revMinor="1" name="Empty" version="1.00" north="0.0" south="0.0" east="0.0" west="0.0" maxRoad="0" maxJunc="0" maxPrg="0">
             </header>
         </OpenDRIVE>""")

--- a/terminus/tests/opendrive_generator_test.py
+++ b/terminus/tests/opendrive_generator_test.py
@@ -34,5 +34,5 @@ class OpenDriveGeneratorTest(unittest.TestCase):
         <?xml version="1.0" standalone="yes"?>
           <OpenDRIVE xmlns="http://www.opendrive.org">
             <header revMajor="1" revMinor="1" name="Empty" version="1.00" north="0.0000000000000000e+00" south="0.0000000000000000e+00" east="0.0000000000000000e+00" west="0.0000000000000000e+00" maxRoad="0" maxJunc="0" maxPrg="0">
-            </header>\n
+            </header>
         </OpenDRIVE>""")

--- a/terminus/tests/opendrive_mapper_id_test.py
+++ b/terminus/tests/opendrive_mapper_id_test.py
@@ -1,0 +1,60 @@
+import unittest
+
+from geometry.point import Point
+from models.city import City
+from models.road import *
+from models.street import Street
+
+from generators.opendrive_id_mapper import OpenDriveIdMapper
+from generators.opendrive_id_mapper import Connection
+from generators.opendrive_id_mapper import Junction
+
+# class Connection(unittest.TestCase):
+
+#     def setUp(self):
+#         self.city = City()
+
+#     def create_cross(self):
+#         self.city.add_road(Street.from_points([Point(0, 0), Point(100, 0)]))
+#         self.city.add_road(Street.from_points([Point(-50, -50), Point(50, 50)]))
+
+#     def get_connections(self):
+#         connections = []
+#         for road in self.city.roads:
+#             exit_waypoints = filter(lambda waypoint: waypoint.is_exit(), road.get_waypoints())
+#             for exit_waypoint in exit_waypoints:
+#                 for entry_waypoint in exit_waypoint.connected_waypoints():
+#                     connection = Connection(exit_waypoint, entry_waypoint)
+#         return connections
+
+#     def test_constructor(self):
+#         self.create_cross()
+#         assertNotEqual(len(self.get_connections()), 0)
+#         for connection in self.get_connections():
+#             assertEqual(connection.entry, entry_waypoint)
+#             assertEqual(connection.exit, exit_waypoint)
+
+#     def test_eq(self):
+#         self.create_cross()
+#         connections = self.get_connections()
+#         assert(connections[0] == connections[0], True)
+#         assert(connections[1] == connections[1], True)
+#         assert(connections[0] == connections[1], False)
+
+
+# class Junction(unittest.TestCase):
+
+#     def setUp(self):
+#         self.city = City()
+
+#     def create_cross(self):
+#         self.city.add_road(Street.from_points([Point(0, 0), Point(100, 0)]))
+#         self.city.add_road(Street.from_points([Point(-50, -50), Point(50, 50)]))
+
+#     def test_add_connection():
+#         self.create_cross()
+#         connections = self.get_connections()
+#         j = Junction(1)
+#         for connection in self.get_connections():
+#             j.add_connection(connection)
+#             assertEqual(j.connections[-1], connection)


### PR DESCRIPTION
I have created the following classes to handle the junctions in the OpenDrive generator:

1. Junctions, Connections and Links. Connections are just the entry - exit waypoint reference. Links are the couple of the incomming road and outgoing road made from the connection. And a junction is made of a list of connections and links.
2. Also defined a child OpenDriveRoad class that comes from Road model. It has some usefull information for the OpenDriveModel.

The process of creating the junction is described below:

1. First, I create the junctions from the available information of the city's roads. I create the connections and then fill the junctions with them.
2. Split the roads into other OpenDrive roads, taking the the first, entry, exit and last waypoints as the cutting points.
3. While creating the OpenDrive roads, I put them inside a map where the key is the hash of the base road and the value is a list of the road segments already split. It will be useful for future queries.
4. Create junction roads. This are the roads that join one exit waypoint with the other entry waypoint. I make use of the map to find the exact road cut. I create the Link here to save the reference between the new road ids.
5. Make use of `end_city` handler to create all the OpenDrive output file. I could not use the other events because road models are new and outside from the city model.

Here are some sample pictures.

![j1](https://cloud.githubusercontent.com/assets/3825465/22220898/62bf53e0-e18f-11e6-8f56-9db09a6be759.png)

![j2](https://cloud.githubusercontent.com/assets/3825465/22220904/6660559e-e18f-11e6-9271-bdf2bbcc1dce.png)

![j3](https://cloud.githubusercontent.com/assets/3825465/22220909/695523d8-e18f-11e6-8e13-3fbd8c8715bb.png)

closes #157 
