### PR TITLE
Monolane generator

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(name='terminus',
           'imposm.parser',
           'scipy',
           'matplotlib',
-          'Pillow'
+          'Pillow',
+          'PyYAML'
       ],
       zip_safe=False)

--- a/terminus/generators/monolane_generator.py
+++ b/terminus/generators/monolane_generator.py
@@ -1,0 +1,203 @@
+from __future__ import print_function
+
+from collections import OrderedDict
+from math import atan2
+from math import degrees
+import yaml
+
+from .city_visitor import CityVisitor
+from models.intersection_node import IntersectionNode
+
+
+class MonolaneGenerator(CityVisitor):
+    def start_city(self, city):
+        """Called when a visitation of a new city starts."""
+        # Reset all of the class variables used until stop_city is called.
+        self.monolane = {
+            'maliput_monolane_builder': OrderedDict([
+                ('id', city.name),
+                ('lane_bounds', [-2, 2]),
+                ('driveable_bounds', [-4, 4]),
+                ('position_precision', 0.01),
+                ('orientation_precision', 0.5),
+                ('points', OrderedDict()),
+                ('connections', OrderedDict()),
+                ('groups', OrderedDict()),
+            ])
+        }
+        self.streets = []
+        self.point_name_by_street_node_dict = {}
+        self.intersection_index = 0
+        self.intersection_index_by_node = {}
+
+    def node_ident(self, street, node):
+        """Return a hashable unique identifier for a street node."""
+        return (street.name, id(node))
+
+    def point_name_by_street_node(self, node, street):
+        """Return the monolane point name for a given street node."""
+        ident = self.node_ident(street, node)
+        return self.point_name_by_street_node_dict[ident][0]
+
+    def new_connection(self, node1, street1, node2, street2):
+        """Add a new monolane connection between two street nodes."""
+        # Get the point names using the street node combo.
+        # These names should have been created while streets were being processed.
+        point1 = self.point_name_by_street_node(node1, street1)
+        point2 = self.point_name_by_street_node(node2, street2)
+
+        # Create a connection name using the two monolane point names.
+        connection_name = "{0}-{1}".format(point1, point2)
+
+        # Create the new connection, explicitly starting with the first point,
+        # ending with the second point, and with a length equal to the distance
+        # between the points.
+        new_monolane_connection = {
+            connection_name: OrderedDict([
+                ('start',
+                    "points.{0}".format(self.point_name_by_street_node(node1, street1))),
+                ('length',
+                    node1.center.distance_to(node2.center)),
+                ('explicit_end',
+                    "points.{0}".format(self.point_name_by_street_node(node2, street2))),
+            ])
+        }
+        # Store the new connection in the monolane dictionary.
+        self.monolane['maliput_monolane_builder']['connections'].update(
+            new_monolane_connection)
+
+    def end_city(self, city):
+        """Called when a city has been completely visited."""
+        # Iterate over all the visited streets (again) and make connections.
+        # This second iteration is required so that connections between streets
+        # can be made, as all nodes of all streets have already been assigned
+        # point names.
+        for street in self.streets:
+            previous_node = None
+            for node in street.get_nodes():
+                # If this is not the first node in the street, make a
+                # connection with the previous node.
+                if previous_node is not None:
+                    self.new_connection(previous_node, street, node, street)
+                previous_node = node
+
+    def process_street(self, street):
+        """Called anytime a street or trunk are visited."""
+        # Add the street to a list of streets to be iterated over when
+        # end_city() is called.
+        self.streets.append(street)
+        # Iterate over all of the nodes in the street, given them unique
+        # monolane names, and add them to the points section in the monolane
+        # dictionary.
+        point_index = 1  # used to uniquely name the points for this street
+        previous_point_name = None  # used to update the heading of the point
+        previous_point_center = None  # used to calculate the heading
+        previous_heading = 0
+        for node in list(street.get_nodes()):
+            # Generate a unique name for the point based on the street name.
+            point_name = '{}-{}'.format(street.name, point_index)
+            point_index += 1
+            # If this is an "IntersectionNode", adjust the name to indicate it.
+            if isinstance(node, IntersectionNode):
+                # Get the index associated with the intersection.
+                if id(node) not in self.intersection_index_by_node:
+                    # Assign an index if this is the first appearance.
+                    self.intersection_index_by_node[id(node)] = self.intersection_index
+                    self.intersection_index += 1
+                index = self.intersection_index_by_node[id(node)]
+                # Adjust the name to include the intersection.
+                point_name = '{}-from_Intersection-{}'.format(point_name, self.intersection_index)
+            # Get a unique and hashable identifier for the street node.
+            node_ident = self.node_ident(street, node)
+            # Ensure it is unique.
+            if node_ident in self.point_name_by_street_node_dict:
+                raise RuntimeError("Non-unique street node identifier. This should not happen.")
+            # Store the point name using the identifier.
+            self.point_name_by_street_node_dict[node_ident] = (point_name, node)
+            # Put the point into the monolane dictionary.
+            new_monolane_point = {
+                point_name: OrderedDict([
+                    ('xypoint', [  # x, y, heading
+                        float(node.center.x),
+                        float(node.center.y),
+                        0  # will be set later using heading between this point and the next
+                    ]),
+                    ('zpoint', [  # z, zdot, theta (superelevation), thetadot
+                        float(node.center.z),
+                        0,
+                        0,
+                        0
+                    ]),
+                ])
+            }
+            # If there was a previous point, calculate the heading from it to this point.
+            if previous_point_name is not None:
+                # Get the previous point's center by name.
+                previous_point = \
+                    self.monolane['maliput_monolane_builder']['points'][previous_point_name]['xypoint']
+                # Calculate the heading.
+                previous_heading = degrees(previous_point_center.yaw(node.center))
+                # Store it.
+                previous_point[2] = previous_heading
+            previous_point_name = point_name
+            previous_point_center = node.center
+            # Insert the new point.
+            self.monolane['maliput_monolane_builder']['points'].update(new_monolane_point)
+        # end for node in list(street.get_nodes())
+        # Update the heading of the last point (last one processed in the for loop).
+        if previous_point_name is not None:
+            # Use the last heading as the heading of the last point.
+            previous_point = \
+                self.monolane['maliput_monolane_builder']['points'][previous_point_name]['xypoint']
+            previous_point[2] = previous_heading
+
+    def start_street(self, street):
+        self.process_street(street)
+
+    def end_street(self, street):
+        pass
+
+    def start_trunk(self, trunk):
+        self.process_street(trunk)
+
+    def end_trunk(self, trunk):
+        pass
+
+    def start_ground_plane(self, plane):
+        pass
+
+    def end_ground_plane(self, plane):
+        pass
+
+    def start_block(self, block):
+        pass
+
+    def end_block(self, block):
+        pass
+
+    def start_building(self, building):
+        pass
+
+    def end_building(self, building):
+        pass
+
+    def to_string(self, stream=None, Dumper=yaml.Dumper, **kwds):
+        """Convert the current monolane data into its yaml version.
+
+        Preserves order of the keys inside of 'maliput_monolane_builder'.
+        """
+        header = """# -*- yaml -*-
+---
+# distances are meters; angles are degrees.
+"""
+
+        class OrderedDumper(yaml.Dumper):
+            pass
+
+        def _dict_representer(dumper, data):
+            return dumper.represent_mapping(
+                yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+                data.items())
+
+        OrderedDumper.add_representer(OrderedDict, _dict_representer)
+        return header + yaml.dump(self.monolane, stream, OrderedDumper, **kwds)

--- a/terminus/generators/monolane_generator.py
+++ b/terminus/generators/monolane_generator.py
@@ -5,11 +5,14 @@ from math import atan2
 from math import degrees
 import yaml
 
-from .city_visitor import CityVisitor
+from .file_generator import FileGenerator
 from models.road_intersection_node import RoadIntersectionNode
 
 
-class MonolaneGenerator(CityVisitor):
+class MonolaneGenerator(FileGenerator):
+    def __init__(self, city):
+        super(MonolaneGenerator, self).__init__(city)
+
     def start_city(self, city):
         """Called when a visitation of a new city starts."""
         # Reset all of the class variables used until stop_city is called.
@@ -157,7 +160,11 @@ class MonolaneGenerator(CityVisitor):
     def start_trunk(self, trunk):
         self.process_street(trunk)
 
-    def to_string(self, stream=None, Dumper=yaml.Dumper, **kwds):
+    def end_document(self):
+        """Called after the document is generated, but before it is written to a file."""
+        self.document.write(self.to_string())
+
+    def to_string(self, Dumper=yaml.Dumper, **kwds):
         """Convert the current monolane data into its yaml version.
 
         Preserves order of the keys inside of 'maliput_monolane_builder'.
@@ -176,4 +183,4 @@ class MonolaneGenerator(CityVisitor):
                 data.items())
 
         OrderedDumper.add_representer(OrderedDict, _dict_representer)
-        return header + yaml.dump(self.monolane, stream, OrderedDumper, **kwds)
+        return header + yaml.dump(self.monolane, None, OrderedDumper, **kwds)

--- a/terminus/generators/monolane_generator.py
+++ b/terminus/generators/monolane_generator.py
@@ -1,12 +1,11 @@
 from __future__ import print_function
 
 from collections import OrderedDict
-from math import atan2
-from math import degrees
+
 import yaml
 
 from .file_generator import FileGenerator
-from models.road_intersection_node import RoadIntersectionNode
+from .monolane_id_mapper import MonolaneIdMapper
 
 
 class MonolaneGenerator(FileGenerator):
@@ -15,6 +14,9 @@ class MonolaneGenerator(FileGenerator):
 
     def start_city(self, city):
         """Called when a visitation of a new city starts."""
+        # First run the id mapper
+        self.monolane_id_mapper = MonolaneIdMapper(city)
+        self.monolane_id_mapper.run()
         # Reset all of the class variables used until stop_city is called.
         self.monolane = {
             'maliput_monolane_builder': OrderedDict([
@@ -23,31 +25,21 @@ class MonolaneGenerator(FileGenerator):
                 ('driveable_bounds', [-4, 4]),
                 ('position_precision', 0.01),
                 ('orientation_precision', 0.5),
-                ('points', OrderedDict()),
+                ('points', self.monolane_id_mapper.get_monolane_points()),
                 ('connections', OrderedDict()),
                 ('groups', OrderedDict()),
             ])
         }
-        self.streets = []
-        self.point_name_by_street_node_dict = {}
-        self.intersection_index = 0
-        self.intersection_index_by_node = {}
 
-    def node_ident(self, street, node):
-        """Return a hashable unique identifier for a street node."""
-        return (street.name, id(node))
+    def point_name_by_road_node(self, road, node):
+        return self.monolane_id_mapper.point_name_by_road_node(road, node)
 
-    def point_name_by_street_node(self, node, street):
-        """Return the monolane point name for a given street node."""
-        ident = self.node_ident(street, node)
-        return self.point_name_by_street_node_dict[ident][0]
-
-    def new_connection(self, node1, street1, node2, street2):
-        """Add a new monolane connection between two street nodes."""
-        # Get the point names using the street node combo.
-        # These names should have been created while streets were being processed.
-        point1 = self.point_name_by_street_node(node1, street1)
-        point2 = self.point_name_by_street_node(node2, street2)
+    def new_connection(self, node1, road1, node2, road2):
+        """Add a new monolane connection between two road nodes."""
+        # Get the point names using the road node combo.
+        # These names were created by the id mapper.
+        point1 = self.point_name_by_road_node(road1, node1)
+        point2 = self.point_name_by_road_node(road2, node2)
 
         # Create a connection name using the two monolane point names.
         connection_name = "{0}-{1}".format(point1, point2)
@@ -58,107 +50,32 @@ class MonolaneGenerator(FileGenerator):
         new_monolane_connection = {
             connection_name: OrderedDict([
                 ('start',
-                    "points.{0}".format(self.point_name_by_street_node(node1, street1))),
+                    "points.{0}".format(self.point_name_by_road_node(road1, node1))),
                 ('length',
                     node1.center.distance_to(node2.center)),
                 ('explicit_end',
-                    "points.{0}".format(self.point_name_by_street_node(node2, street2))),
+                    "points.{0}".format(self.point_name_by_road_node(road2, node2))),
             ])
         }
         # Store the new connection in the monolane dictionary.
         self.monolane['maliput_monolane_builder']['connections'].update(
             new_monolane_connection)
 
-    def end_city(self, city):
-        """Called when a city has been completely visited."""
-        # Iterate over all the visited streets (again) and make connections.
-        # This second iteration is required so that connections between streets
-        # can be made, as all nodes of all streets have already been assigned
-        # point names.
-        for street in self.streets:
-            previous_node = None
-            for node in street.get_nodes():
-                # If this is not the first node in the street, make a
-                # connection with the previous node.
-                if previous_node is not None:
-                    self.new_connection(previous_node, street, node, street)
-                previous_node = node
-
-    def process_street(self, street):
+    def process_road(self, road):
         """Called anytime a street or trunk are visited."""
-        # Add the street to a list of streets to be iterated over when
-        # end_city() is called.
-        self.streets.append(street)
-        # Iterate over all of the nodes in the street, given them unique
-        # monolane names, and add them to the points section in the monolane
-        # dictionary.
-        point_index = 1  # used to uniquely name the points for this street
-        previous_point_name = None  # used to update the heading of the point
-        previous_point_center = None  # used to calculate the heading
-        previous_heading = 0
-        for node in list(street.get_nodes()):
-            # Generate a unique name for the point based on the street name.
-            point_name = '{}-{}'.format(street.name, point_index)
-            point_index += 1
-            # If this is an "RoadIntersectionNode", adjust the name to indicate it.
-            if isinstance(node, RoadIntersectionNode):
-                # Get the index associated with the intersection.
-                if id(node) not in self.intersection_index_by_node:
-                    # Assign an index if this is the first appearance.
-                    self.intersection_index_by_node[id(node)] = self.intersection_index
-                    self.intersection_index += 1
-                index = self.intersection_index_by_node[id(node)]
-                # Adjust the name to include the intersection.
-                point_name = '{}-from_Intersection-{}'.format(point_name, self.intersection_index)
-            # Get a unique and hashable identifier for the street node.
-            node_ident = self.node_ident(street, node)
-            # Ensure it is unique.
-            if node_ident in self.point_name_by_street_node_dict:
-                raise RuntimeError("Non-unique street node identifier. This should not happen.")
-            # Store the point name using the identifier.
-            self.point_name_by_street_node_dict[node_ident] = (point_name, node)
-            # Put the point into the monolane dictionary.
-            new_monolane_point = {
-                point_name: OrderedDict([
-                    ('xypoint', [  # x, y, heading
-                        float(node.center.x),
-                        float(node.center.y),
-                        0  # will be set later using heading between this point and the next
-                    ]),
-                    ('zpoint', [  # z, zdot, theta (superelevation), thetadot
-                        float(node.center.z),
-                        0,
-                        0,
-                        0
-                    ]),
-                ])
-            }
-            # If there was a previous point, calculate the heading from it to this point.
-            if previous_point_name is not None:
-                # Get the previous point's center by name.
-                previous_point = \
-                    self.monolane['maliput_monolane_builder']['points'][previous_point_name]['xypoint']
-                # Calculate the heading.
-                previous_heading = degrees(previous_point_center.yaw(node.center))
-                # Store it.
-                previous_point[2] = previous_heading
-            previous_point_name = point_name
-            previous_point_center = node.center
-            # Insert the new point.
-            self.monolane['maliput_monolane_builder']['points'].update(new_monolane_point)
-        # end for node in list(street.get_nodes())
-        # Update the heading of the last point (last one processed in the for loop).
-        if previous_point_name is not None:
-            # Use the last heading as the heading of the last point.
-            previous_point = \
-                self.monolane['maliput_monolane_builder']['points'][previous_point_name]['xypoint']
-            previous_point[2] = previous_heading
+        previous_node = None
+        for node in road.get_nodes():
+            # If this is not the first node in the road, make a
+            # connection with the previous node.
+            if previous_node is not None:
+                self.new_connection(previous_node, road, node, road)
+            previous_node = node
 
     def start_street(self, street):
-        self.process_street(street)
+        self.process_road(street)
 
     def start_trunk(self, trunk):
-        self.process_street(trunk)
+        self.process_road(trunk)
 
     def end_document(self):
         """Called after the document is generated, but before it is written to a file."""

--- a/terminus/generators/monolane_generator.py
+++ b/terminus/generators/monolane_generator.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from collections import OrderedDict
 
 import yaml

--- a/terminus/generators/monolane_generator.py
+++ b/terminus/generators/monolane_generator.py
@@ -6,7 +6,7 @@ from math import degrees
 import yaml
 
 from .city_visitor import CityVisitor
-from models.intersection_node import IntersectionNode
+from models.road_intersection_node import RoadIntersectionNode
 
 
 class MonolaneGenerator(CityVisitor):
@@ -97,8 +97,8 @@ class MonolaneGenerator(CityVisitor):
             # Generate a unique name for the point based on the street name.
             point_name = '{}-{}'.format(street.name, point_index)
             point_index += 1
-            # If this is an "IntersectionNode", adjust the name to indicate it.
-            if isinstance(node, IntersectionNode):
+            # If this is an "RoadIntersectionNode", adjust the name to indicate it.
+            if isinstance(node, RoadIntersectionNode):
                 # Get the index associated with the intersection.
                 if id(node) not in self.intersection_index_by_node:
                     # Assign an index if this is the first appearance.

--- a/terminus/generators/monolane_generator.py
+++ b/terminus/generators/monolane_generator.py
@@ -154,32 +154,8 @@ class MonolaneGenerator(CityVisitor):
     def start_street(self, street):
         self.process_street(street)
 
-    def end_street(self, street):
-        pass
-
     def start_trunk(self, trunk):
         self.process_street(trunk)
-
-    def end_trunk(self, trunk):
-        pass
-
-    def start_ground_plane(self, plane):
-        pass
-
-    def end_ground_plane(self, plane):
-        pass
-
-    def start_block(self, block):
-        pass
-
-    def end_block(self, block):
-        pass
-
-    def start_building(self, building):
-        pass
-
-    def end_building(self, building):
-        pass
 
     def to_string(self, stream=None, Dumper=yaml.Dumper, **kwds):
         """Convert the current monolane data into its yaml version.

--- a/terminus/generators/monolane_id_mapper.py
+++ b/terminus/generators/monolane_id_mapper.py
@@ -1,0 +1,120 @@
+from collections import OrderedDict
+from math import degrees
+
+from city_visitor import CityVisitor
+from models.road_intersection_node import RoadIntersectionNode
+
+
+class MonolaneIdMapper(CityVisitor):
+    """Simple city visitor that generates the Monolane point names ("id's").
+
+    This class refers to "road nodes", which in this case is a unique
+    combination of a road (a street or a trunk) with a node.
+    The node might be a RoadIntersectionNode, in which case the node might
+    be associated with more than one road.
+    For the purposes of Monolane, this is not OK, so we create a point name per
+    road-node pair.
+    """
+
+    def run(self):
+        self.point_name_by_road_node_dict = {}
+        self.intersection_index = 0
+        self.intersection_index_by_node = {}
+        self.monolane_points = OrderedDict()
+        super(MonolaneIdMapper, self).run()
+
+    def road_node_id(self, road, node):
+        """Return a hashable unique identifier for a road node."""
+        if road.name is None:
+            print(road)
+        return (road.name, id(node))
+
+    def get_monolane_points(self):
+        return self.monolane_points
+
+    def point_name_by_road_node(self, road, node):
+        return self.point_name_by_road_node_dict[self.road_node_id(road, node)]
+
+    def process_road(self, road):
+        """Called anytime a road or trunk are visited.
+
+        Each node in the road is given a unique monolane point name which is
+        based on both the node and the road name.
+        It takes this form:
+
+            <road.name>-<point_index>[-from_Intersection-<intersection_index>]
+
+        The ``point_index`` is unique within a single road, i.e. it is reset
+        each time a new road is processed.
+        The optional suffix is added if the node is a ``RoadIntersectionNode``.
+        The optional suffix uses ``intersection_index`` which is the unique
+        number associated with each ``RoadIntersectionNode`` in the city.
+        """
+        # Iterate over all of the nodes in the road, given them unique
+        # monolane point names, and store them for later use.
+        point_index = 1  # used to uniquely name the points for this road
+        previous_point_name = None
+        previous_point_center = None
+        previous_heading = 0
+        for node in list(road.get_nodes()):
+            # Generate a unique name for the point based on the road name.
+            point_name = '{}-{}'.format(road.name, point_index)
+            point_index += 1
+            # If this is an "RoadIntersectionNode", adjust the name to indicate it.
+            if isinstance(node, RoadIntersectionNode):
+                # Get the index associated with the intersection.
+                if id(node) not in self.intersection_index_by_node:
+                    # Assign an index if this is the first appearance.
+                    self.intersection_index_by_node[id(node)] = self.intersection_index
+                    self.intersection_index += 1
+                index = self.intersection_index_by_node[id(node)]
+                # Adjust the name to include the intersection.
+                point_name = '{}-from_Intersection-{}'.format(point_name, index)
+            # Get a unique and hash-able identifier for the road node.
+            node_ident = self.road_node_id(road, node)
+            # Ensure it is unique.
+            if node_ident in self.point_name_by_road_node_dict:
+                raise RuntimeError("Non-unique road node identifier. This should not happen.")
+            # Store the point name using the identifier.
+            self.point_name_by_road_node_dict[node_ident] = (point_name, node)
+            # Put the point into the monolane dictionary.
+            new_monolane_point = {
+                point_name: OrderedDict([
+                    ('xypoint', [  # x, y, heading
+                        float(node.center.x),
+                        float(node.center.y),
+                        0  # will be set later using heading between this point and the next
+                    ]),
+                    ('zpoint', [  # z, zdot, theta (superelevation), thetadot
+                        float(node.center.z),
+                        0,
+                        0,
+                        0
+                    ]),
+                ])
+            }
+            # If there was a previous point, calculate the heading from it to this point.
+            if previous_point_name is not None:
+                # Get the previous point's center by name.
+                previous_point = self.monolane_points[previous_point_name]['xypoint']
+                # Calculate the heading.
+                previous_heading = degrees(previous_point_center.yaw(node.center))
+                # Store it.
+                previous_point[2] = previous_heading
+            previous_point_name = point_name
+            previous_point_center = node.center
+            # Insert the new point.
+            self.monolane_points.update(new_monolane_point)
+        # end for node in list(road.get_nodes())
+
+        # Update the heading of the last point (last one processed in the for loop).
+        if previous_point_name is not None:
+            # Use the last heading as the heading of the last point.
+            previous_point = self.monolane_points[previous_point_name]['xypoint']
+            previous_point[2] = previous_heading
+
+    def start_street(self, street):
+        self.process_road(street)
+
+    def start_trunk(self, trunk):
+        self.process_road(trunk)

--- a/terminus/generators/monolane_id_mapper.py
+++ b/terminus/generators/monolane_id_mapper.py
@@ -25,8 +25,6 @@ class MonolaneIdMapper(CityVisitor):
 
     def road_node_id(self, road, node):
         """Return a hashable unique identifier for a road node."""
-        if road.name is None:
-            print(road)
         return (road.name, id(node))
 
     def get_monolane_points(self):

--- a/terminus/run_generator.py
+++ b/terminus/run_generator.py
@@ -1,12 +1,17 @@
 #!/usr/bin/python
 
+from __future__ import print_function
+
 from geometry.latlon import LatLon
 from generators.rndf_generator import RNDFGenerator
 from generators.sdf_generator_gazebo_7 import SDFGeneratorGazebo7
 from generators.sdf_generator_gazebo_8 import SDFGeneratorGazebo8
 from generators.street_plot_generator import StreetPlotGenerator
 from generators.opendrive_generator import OpenDriveGenerator
-from builders import *
+
+from builders import OsmCityBuilder
+from builders import ProceduralCityBuilder
+from builders import SimpleCityBuilder
 
 import argparse
 import sys
@@ -62,6 +67,12 @@ destination_street_plot_file = base_path + '_streets.png'
 destination_opendrive_file = base_path + '.xodr'
 
 # Get the class of the builder to use
+builders_list = [
+    OsmCityBuilder,
+    ProceduralCityBuilder,
+    SimpleCityBuilder
+]
+assert(arguments.builder in [x.__name__ for x in builders_list])
 builder_class = getattr(sys.modules[__name__], arguments.builder)
 
 # Get the remaining parameters to pass to the builder as <key>=<value> pairs

--- a/terminus/run_generator.py
+++ b/terminus/run_generator.py
@@ -3,6 +3,7 @@
 from __future__ import print_function
 
 from geometry.latlon import LatLon
+from generators.monolane_generator import MonolaneGenerator
 from generators.rndf_generator import RNDFGenerator
 from generators.sdf_generator_gazebo_7 import SDFGeneratorGazebo7
 from generators.sdf_generator_gazebo_8 import SDFGeneratorGazebo8
@@ -65,6 +66,7 @@ destination_sdf_7_file = base_path + '_gazebo_7.sdf'
 destination_sdf_8_file = base_path + '_gazebo_8.sdf'
 destination_street_plot_file = base_path + '_streets.png'
 destination_opendrive_file = base_path + '.xodr'
+destination_monolane_file = base_path + '.monolane.yaml'
 
 # Get the class of the builder to use
 builders_list = [
@@ -117,3 +119,9 @@ rndf_generator.write_to(destination_rndf_file)
 logger.info("Generating OpenDrive file")
 opendrive_generator = OpenDriveGenerator(city, RNDF_ORIGIN)
 opendrive_generator.write_to(destination_opendrive_file)
+
+logger.info("Generating monolane file")
+monolane_generator = MonolaneGenerator(city)
+monolane_generator.run()
+with open(destination_monolane_file, 'w+') as f:
+    f.write(monolane_generator.to_string())

--- a/terminus/run_generator.py
+++ b/terminus/run_generator.py
@@ -1,7 +1,5 @@
 #!/usr/bin/python
 
-from __future__ import print_function
-
 from geometry.latlon import LatLon
 from generators.monolane_generator import MonolaneGenerator
 from generators.rndf_generator import RNDFGenerator

--- a/terminus/run_generator.py
+++ b/terminus/run_generator.py
@@ -122,6 +122,4 @@ opendrive_generator.write_to(destination_opendrive_file)
 
 logger.info("Generating monolane file")
 monolane_generator = MonolaneGenerator(city)
-monolane_generator.run()
-with open(destination_monolane_file, 'w+') as f:
-    f.write(monolane_generator.to_string())
+monolane_generator.write_to(destination_monolane_file)

--- a/terminus/tests/common_generator_test_cases.py
+++ b/terminus/tests/common_generator_test_cases.py
@@ -1,0 +1,115 @@
+from geometry.point import Point
+from geometry.latlon import LatLon
+from models.city import City
+from models.street import Street
+from models.trunk import Trunk
+
+def generate_empty_city():
+    city = City("Empty")
+    return city
+
+
+def generate_simple_street_city():
+    city = City("Single street")
+    street = Street.from_points([
+        Point(0, 0),
+        Point(1000, 0),
+        Point(2000, 0)
+    ])
+    street.name = "s1"
+    city.add_road(street)
+    return city
+
+
+def generate_cross_intersection_city():
+    """
+         (0,1)
+    (-1,0) + (1,0)
+         (0,-1)
+    """
+    city = City("Cross")
+
+    s1 = Street.from_points([Point(-1000, 0), Point(0, 0), Point(1000, 0)])
+    s1.name = "s1"
+
+    s2 = Street.from_points([Point(0, 1000), Point(0, 0), Point(0, -1000)])
+    s2.name = "s2"
+
+    city.add_intersection_at(Point(0, 0))
+
+    city.add_road(s1)
+    city.add_road(s2)
+
+    return city
+
+def generate_L_intersection_city():
+    """
+         (0,1)
+           +  (1,0)
+    """
+    city = City("LCross")
+
+    s1 = Street.from_points([Point(0, 1000), Point(0, 0)])
+    s1.name = "s1"
+
+    s2 = Street.from_points([Point(0, 0), Point(1000, 0)])
+    s2.name = "s2"
+
+    city.add_intersection_at(Point(0, 0))
+
+    city.add_road(s1)
+    city.add_road(s2)
+
+    return city
+
+
+def generate_Y_intersection_city():
+    """
+              (0,1)
+                +
+        (-1,-1)   (1,-1)
+    """
+    city = City("YCross")
+
+    s1 = Street.from_points([Point(0, 1000), Point(0, 0)])
+    s1.name = "s1"
+
+    s2 = Street.from_points([Point(0, 0), Point(-1000, -1000)])
+    s2.name = "s2"
+
+    s3 = Street.from_points([Point(0, 0), Point(1000, -1000)])
+    s3.name = "s3"
+
+    city.add_intersection_at(Point(0, 0))
+
+    city.add_road(s1)
+    city.add_road(s2)
+    city.add_road(s3)
+
+    return city
+
+
+def generate_Y_intersection_many_to_one_city():
+    """
+              (0,1)
+                +
+        (-1,-1)   (1,-1)
+    """
+    city = City("YCross Many to One")
+
+    s1 = Street.from_points([Point(0, 0), Point(0, 1000)])
+    s1.name = "s1"
+
+    s2 = Street.from_points([Point(-1000, -1000), Point(0, 0)])
+    s2.name = "s2"
+
+    s3 = Street.from_points([Point(1000, -1000), Point(0, 0)])
+    s3.name = "s3"
+
+    city.add_road(s1)
+    city.add_road(s2)
+    city.add_road(s3)
+
+    city.add_intersection_at(Point(0, 0))
+
+    return city

--- a/terminus/tests/common_generator_test_cases.py
+++ b/terminus/tests/common_generator_test_cases.py
@@ -1,8 +1,7 @@
 from geometry.point import Point
-from geometry.latlon import LatLon
 from models.city import City
 from models.street import Street
-from models.trunk import Trunk
+
 
 def generate_empty_city():
     city = City("Empty")
@@ -41,6 +40,7 @@ def generate_cross_intersection_city():
     city.add_road(s2)
 
     return city
+
 
 def generate_L_intersection_city():
     """

--- a/terminus/tests/common_generator_test_cases.py
+++ b/terminus/tests/common_generator_test_cases.py
@@ -63,7 +63,7 @@ def generate_L_intersection_city():
     return city
 
 
-def generate_Y_intersection_city():
+def generate_Y_intersection_one_to_many_city():
     """
               (0,1)
                 +

--- a/terminus/tests/monolane_generator_test.py
+++ b/terminus/tests/monolane_generator_test.py
@@ -1,0 +1,100 @@
+import unittest
+import yaml
+
+from generators.monolane_generator import MonolaneGenerator
+
+from common_generator_test_cases import generate_cross_intersection_city
+from common_generator_test_cases import generate_empty_city
+from common_generator_test_cases import generate_L_intersection_city
+from common_generator_test_cases import generate_simple_street_city
+from common_generator_test_cases import generate_Y_intersection_one_to_many_city
+from common_generator_test_cases import generate_Y_intersection_many_to_one_city
+
+
+class MonolaneGeneratorTest(unittest.TestCase):
+
+    def generate_monolane(self, city):
+        self.generator = MonolaneGenerator(city)
+        self.generated_contents = self.generator.generate()
+        print(self.generated_contents)
+        self.yaml_dict = yaml.load(self.generated_contents)
+        monolane_dict = self.yaml_dict['maliput_monolane_builder']
+        self.standard_checks(city, monolane_dict)
+        return monolane_dict
+
+    def standard_checks(self, city, monolane_dict):
+        self.assertEqual(city.name, monolane_dict['id'])
+        # Ensure each road is somewhat represented in the point names.
+        all_point_names = list(monolane_dict['points'].keys())
+        for road in city.roads:
+            self.assertTrue(
+                any([x for x in all_point_names if road.name in x]),
+                msg="The name for road '{}' does not appear in any point names.".format(road.name))
+        # For now groups are always empty.
+        self.assertEqual(0, len(monolane_dict['groups']))
+
+    def test_empty_city(self):
+        city = generate_empty_city()
+
+        monolane_dict = self.generate_monolane(city)
+
+        self.assertEqual(0, len(monolane_dict['points']))
+        self.assertEqual(0, len(monolane_dict['connections']))
+
+    def test_simple_street(self):
+        city = generate_simple_street_city()
+
+        monolane_dict = self.generate_monolane(city)
+
+        self.assertEqual(3, len(monolane_dict['points']))
+        self.assertEqual(2, len(monolane_dict['connections']))
+
+    def test_cross_intersection(self):
+        city = generate_cross_intersection_city()
+
+        monolane_dict = self.generate_monolane(city)
+
+        self.assertEqual(6, len(monolane_dict['points']))
+        self.assertEqual(4, len(monolane_dict['connections']))
+        # Make sure two of the points are part of the intersection.
+        self.assertEqual(2, len([x for x in monolane_dict['points'] if 'Intersection' in x]))
+        # Make sure there is only one intersection, i.e. no Intersection-2, only Intersection-1.
+        self.assertFalse(any([x for x in monolane_dict['points'] if 'Intersection-2' in x]))
+
+    def test_L_intersection(self):
+        city = generate_L_intersection_city()
+
+        monolane_dict = self.generate_monolane(city)
+
+        self.assertEqual(4, len(monolane_dict['points']))
+        self.assertEqual(2, len(monolane_dict['connections']))
+        # Make sure two of the points are part of the intersection.
+        self.assertEqual(2, len([x for x in monolane_dict['points'] if 'Intersection' in x]))
+        # Make sure there is only one intersection, i.e. no Intersection-2, only Intersection-1.
+        self.assertFalse(any([x for x in monolane_dict['points'] if 'Intersection-2' in x]))
+
+
+    def test_Y_intersection_one_to_many(self):
+        city = generate_Y_intersection_one_to_many_city()
+
+        monolane_dict = self.generate_monolane(city)
+
+        self.assertEqual(6, len(monolane_dict['points']))
+        self.assertEqual(3, len(monolane_dict['connections']))
+        # Make sure two of the points are part of the intersection.
+        self.assertEqual(3, len([x for x in monolane_dict['points'] if 'Intersection' in x]))
+        # Make sure there is only one intersection, i.e. no Intersection-2, only Intersection-1.
+        self.assertFalse(any([x for x in monolane_dict['points'] if 'Intersection-2' in x]))
+
+
+    def test_Y_intersection_many_to_one(self):
+        city = generate_Y_intersection_many_to_one_city()
+
+        monolane_dict = self.generate_monolane(city)
+
+        self.assertEqual(6, len(monolane_dict['points']))
+        self.assertEqual(3, len(monolane_dict['connections']))
+        # Make sure two of the points are part of the intersection.
+        self.assertEqual(3, len([x for x in monolane_dict['points'] if 'Intersection' in x]))
+        # Make sure there is only one intersection, i.e. no Intersection-2, only Intersection-1.
+        self.assertFalse(any([x for x in monolane_dict['points'] if 'Intersection-2' in x]))

--- a/terminus/tests/monolane_generator_test.py
+++ b/terminus/tests/monolane_generator_test.py
@@ -16,7 +16,6 @@ class MonolaneGeneratorTest(unittest.TestCase):
     def generate_monolane(self, city):
         self.generator = MonolaneGenerator(city)
         self.generated_contents = self.generator.generate()
-        print(self.generated_contents)
         self.yaml_dict = yaml.load(self.generated_contents)
         monolane_dict = self.yaml_dict['maliput_monolane_builder']
         self.standard_checks(city, monolane_dict)

--- a/terminus/tests/monolane_generator_test.py
+++ b/terminus/tests/monolane_generator_test.py
@@ -1,4 +1,5 @@
 import unittest
+
 import yaml
 
 from generators.monolane_generator import MonolaneGenerator
@@ -72,7 +73,6 @@ class MonolaneGeneratorTest(unittest.TestCase):
         # Make sure there is only one intersection, i.e. no Intersection-2, only Intersection-1.
         self.assertFalse(any([x for x in monolane_dict['points'] if 'Intersection-2' in x]))
 
-
     def test_Y_intersection_one_to_many(self):
         city = generate_Y_intersection_one_to_many_city()
 
@@ -84,7 +84,6 @@ class MonolaneGeneratorTest(unittest.TestCase):
         self.assertEqual(3, len([x for x in monolane_dict['points'] if 'Intersection' in x]))
         # Make sure there is only one intersection, i.e. no Intersection-2, only Intersection-1.
         self.assertFalse(any([x for x in monolane_dict['points'] if 'Intersection-2' in x]))
-
 
     def test_Y_intersection_many_to_one(self):
         city = generate_Y_intersection_many_to_one_city()

--- a/terminus/tests/rndf_generator_test.py
+++ b/terminus/tests/rndf_generator_test.py
@@ -9,6 +9,13 @@ from models.trunk import Trunk
 
 from generators.rndf_generator import RNDFGenerator
 
+from common_generator_test_cases import generate_cross_intersection_city
+from common_generator_test_cases import generate_empty_city
+from common_generator_test_cases import generate_L_intersection_city
+from common_generator_test_cases import generate_simple_street_city
+from common_generator_test_cases import generate_Y_intersection_one_to_many_city
+from common_generator_test_cases import generate_Y_intersection_many_to_one_city
+
 import textwrap
 
 
@@ -30,7 +37,7 @@ class RNDFGeneratorTest(unittest.TestCase):
         self.assertMultiLineEqual(self.generated_contents, expected)
 
     def test_empty_city(self):
-        city = City("Empty")
+        city = generate_empty_city()
         self._generate_rndf(city)
         self._assert_contents_are("""
         RNDF_name\tEmpty
@@ -40,14 +47,7 @@ class RNDFGeneratorTest(unittest.TestCase):
         end_file""")
 
     def test_simple_street(self):
-        city = City("Single street")
-        street = Street.from_points([
-            Point(0, 0),
-            Point(1000, 0),
-            Point(2000, 0)
-        ])
-        street.name = "s1"
-        city.add_road(street)
+        city = generate_simple_street_city()
         self._generate_rndf(city)
         self._assert_contents_are("""
         RNDF_name\tSingle street
@@ -68,24 +68,12 @@ class RNDFGeneratorTest(unittest.TestCase):
         end_file""")
 
     def test_cross_intersection(self):
-
         """
              (0,1)
         (-1,0) + (1,0)
              (0,-1)
         """
-        city = City("Cross")
-
-        s1 = Street.from_points([Point(-1000, 0), Point(0, 0), Point(1000, 0)])
-        s1.name = "s1"
-
-        s2 = Street.from_points([Point(0, 1000), Point(0, 0), Point(0, -1000)])
-        s2.name = "s2"
-
-        city.add_intersection_at(Point(0, 0))
-
-        city.add_road(s1)
-        city.add_road(s2)
+        city = generate_cross_intersection_city()
 
         self._generate_rndf(city)
         self._assert_contents_are("""
@@ -122,23 +110,11 @@ class RNDFGeneratorTest(unittest.TestCase):
         end_file""")
 
     def test_L_intersection(self):
-
         """
              (0,1)
                +  (1,0)
         """
-        city = City("LCross")
-
-        s1 = Street.from_points([Point(0, 1000), Point(0, 0)])
-        s1.name = "s1"
-
-        s2 = Street.from_points([Point(0, 0), Point(1000, 0)])
-        s2.name = "s2"
-
-        city.add_intersection_at(Point(0, 0))
-
-        city.add_road(s1)
-        city.add_road(s2)
+        city = generate_L_intersection_city()
 
         self._generate_rndf(city)
         self._assert_contents_are("""
@@ -172,28 +148,12 @@ class RNDFGeneratorTest(unittest.TestCase):
         end_file""")
 
     def test_Y_intersection_one_to_many(self):
-
         """
                   (0,1)
                     +
             (-1,-1)   (1,-1)
         """
-        city = City("YCross")
-
-        s1 = Street.from_points([Point(0, 1000), Point(0, 0)])
-        s1.name = "s1"
-
-        s2 = Street.from_points([Point(0, 0), Point(-1000, -1000)])
-        s2.name = "s2"
-
-        s3 = Street.from_points([Point(0, 0), Point(1000, -1000)])
-        s3.name = "s3"
-
-        city.add_intersection_at(Point(0, 0))
-
-        city.add_road(s1)
-        city.add_road(s2)
-        city.add_road(s3)
+        city = generate_Y_intersection_one_to_many_city()
 
         self._generate_rndf(city)
         self._assert_contents_are("""
@@ -239,32 +199,16 @@ class RNDFGeneratorTest(unittest.TestCase):
         end_file""")
 
     def test_Y_intersection_many_to_one(self):
-
         """
                   (0,1)
                     +
             (-1,-1)   (1,-1)
         """
-        city = City("YCross")
-
-        s1 = Street.from_points([Point(0, 0), Point(0, 1000)])
-        s1.name = "s1"
-
-        s2 = Street.from_points([Point(-1000, -1000), Point(0, 0)])
-        s2.name = "s2"
-
-        s3 = Street.from_points([Point(1000, -1000), Point(0, 0)])
-        s3.name = "s3"
-
-        city.add_road(s1)
-        city.add_road(s2)
-        city.add_road(s3)
-
-        city.add_intersection_at(Point(0, 0))
+        city = generate_Y_intersection_many_to_one_city()
 
         self._generate_rndf(city)
         self._assert_contents_are("""
-        RNDF_name\tYCross
+        RNDF_name\tYCross Many to One
         num_segments\t3
         num_zones\t0
         format_version\t1.0


### PR DESCRIPTION
This pull request adds the experimental monolane generator (both the module for it and adds it to the `run_generator.py` script).

It also changes slightly how the builders are imported in the `run_generator.py` script because my editor cannot do local variable checking when `from X import *` is used. We can exclude that commit if you guys want, but I think it is best to avoid that kind of import in general.

---

The monolane generator is able to produce a monolane `.yaml` file which can be converted to an `.obj` file using the `yaml_to_obj` executable from drake. This is the command I use to convert the `.yaml` into the `.obj` file:

```
../drake/bazel-bin/drake/automotive/maliput/utility/yaml_to_obj -yaml_file ./generated_worlds/city.monolane.yaml -obj_file city -obj_dir ./generated_worlds
```

Obviously you'd have to have already built drake (in this case I'm using bazel to do so rather than cmake) and also replace the path to the executable according to where you built it.

However, there is still an issue with the geometry and so the default version of this executable (`yaml_to_obj`) will fail without disabling some of the error checking. I used this patch:

```diff
diff --git a/drake/automotive/maliput/monolane/builder.cc b/drake/automotive/maliput/monolane/builder.cc
index 2bc60fb..c0afd02 100644
--- a/drake/automotive/maliput/monolane/builder.cc
+++ b/drake/automotive/maliput/monolane/builder.cc
@@ -306,7 +306,7 @@ std::unique_ptr<const api::RoadGeometry> Builder::Build(
   for (const auto& s : failures) {
     drake::log()->error(s);
   }
-  DRAKE_DEMAND(failures.size() == 0);
+  // DRAKE_DEMAND(failures.size() == 0);
 
   return std::move(road_geometry);
 }
```

The generation still works despite the errors which look something like this:

```
[2017-02-03 17:54:38.445] [console] [error] Lane l:trunk_88-5-trunk_88-6[start] orientation is off by 0.0574029.
```

To solve this we will need to address some of the geometric issues with the road layouts. What RNDF needs doesn't exactly line up with what monolane expects, but I have stopped short of implementing this because I believe these kinds of geometry calculations would be useful outside of the monolane generator and probably should be integrated into terminus directly. I will create an issue about this in more detail after this is merged.

Also, if the road segment is very short (common in the OSM output) then drake will not convert because the arrow it wants to draw on the road is longer than the road. This isn't fatal so I disabled that as well with this patch:

```diff
diff --git a/drake/automotive/maliput/utility/generate_obj.cc b/drake/automotive/maliput/utility/generate_obj.cc
index 86e117c..86d7f08 100644
--- a/drake/automotive/maliput/utility/generate_obj.cc
+++ b/drake/automotive/maliput/utility/generate_obj.cc
@@ -408,7 +408,7 @@ void StripeLaneBounds(GeoMesh* mesh, const api::Lane* lane,
 void DrawLaneArrow(GeoMesh* mesh, const api::Lane* lane, double grid_unit,
                    double s_offset, double s_size, double h_offset) {
   DRAKE_DEMAND(s_offset >= 0.);
-  DRAKE_DEMAND((s_offset + s_size) <= lane->length());
+  // DRAKE_DEMAND((s_offset + s_size) <= lane->length());
   const double kRelativeWidth = 0.8;
 
   const api::RBounds rb0 = lane->lane_bounds(s_offset);

```

I believe this should be addressed upstream in drake at some point. I'll open an issue there after this is merged.

----

I think use `meshlab` to view the `.obj` file. Here are some examples of what is generated:

`SimpleCityBuilder`:

![screenshot from 2017-02-03 17-52-06](https://cloud.githubusercontent.com/assets/100427/22614626/8973fee8-ea39-11e6-82c4-66ce847fba74.png)

OSM at OSRF:

![screenshot from 2017-02-03 17-53-21](https://cloud.githubusercontent.com/assets/100427/22614636/b0c10040-ea39-11e6-9145-632187200cbf.png)

`ProceduralCityBuilder`:

![screenshot from 2017-02-03 17-56-04](https://cloud.githubusercontent.com/assets/100427/22614657/11fb92d0-ea3a-11e6-872a-63d61ea97bfd.png)

----

Other than the "orientation is off by" errors (which make the output of this generator still not very useful since it requires drake patches to parse it), there are two more main issues that need to be addressed. Both are related to intersections and I'll make new issues for those when this is merged, but I'll briefly describe both of them.

The first is that monolane typically creates arcs between road non-co-linear connections (both at intersections and normal nodes) to have continuous geometry (this is related to the orientation error). For example, this is what one of their hand crafted monolane files looks like after obj generation:

![screenshot from 2017-02-03 18-01-41](https://cloud.githubusercontent.com/assets/100427/22614712/dad6aa28-ea3a-11e6-9349-15be618b396d.png)

But in contrast this is the center intersection for the simple city based on this generator:

![screenshot from 2017-02-03 18-02-57](https://cloud.githubusercontent.com/assets/100427/22614721/038040a6-ea3b-11e6-8db9-728b1e7208f2.png)

I think this might need to be addressed more generally in terminus since it would probably be useful to have non-disjoint road geometry for other generators too (maybe gazebo?).

The second is how the connections in monolane are created by this generator. It creates many unrelated connections between points in space, rather than chaining off of other existing connections. This might have adverse effects on how the monolane file is used programmatically, but I'm not certain about that.

CC @nkoenig
