### PR TITLE
Monolane research

### DIFF
--- a/terminus/builders/procedural_city/vertex_graph_to_roads_converter.py
+++ b/terminus/builders/procedural_city/vertex_graph_to_roads_converter.py
@@ -39,10 +39,13 @@ class VertexGraphToRoadsConverter(object):
                                  key=lambda node: node.neighbours_to_traverse_count())
             node = to_traverse.pop(0)
             while node.get_neighbours_to_traverse():
-                if node.is_minor_road:
-                    road = Street()
-                else:
-                    road = Trunk()
+                # Revert this commented code once we support trunks in monolane
+                # generator
+                # if node.is_minor_road:
+                #     road = Street()
+                # else:
+                #     road = Trunk()
+                road = Street()
                 if node.neighbours_count() > 1:
                     self.city.add_intersection_at(node.location)
 

--- a/terminus/builders/simple_city_builder.py
+++ b/terminus/builders/simple_city_builder.py
@@ -102,22 +102,22 @@ class SimpleCityBuilder(AbstractCityBuilder):
         city.add_road(road)
 
     def _create_surrounding_ring_road(self, city, size):
-        ring_road_1 = Trunk(name='RingRoad1')
+        ring_road_1 = Street(name='RingRoad1')
         for x in range(size):
             ring_road_1.add_point(self.intersections[x][0])
         city.add_road(ring_road_1)
 
-        ring_road_2 = Trunk(name='RingRoad2')
+        ring_road_2 = Street(name='RingRoad2')
         for y in range(size):
             ring_road_2.add_point(self.intersections[size - 1][y])
         city.add_road(ring_road_2)
 
-        ring_road_3 = Trunk(name='RingRoad3')
+        ring_road_3 = Street(name='RingRoad3')
         for x in range(size):
             ring_road_3.add_point(self.intersections[size - x - 1][size - 1])
         city.add_road(ring_road_3)
 
-        ring_road_4 = Trunk(name='RingRoad4')
+        ring_road_4 = Street(name='RingRoad4')
         for y in range(size):
             ring_road_4.add_point(self.intersections[0][size - y - 1])
         city.add_road(ring_road_4)

--- a/terminus/city_generation_process.py
+++ b/terminus/city_generation_process.py
@@ -110,7 +110,7 @@ class CityGenerationProcess(object):
 
         if self.debug_on and os.environ['DRAKE_DISTRO']:
             # Generate OBJ from monolane if binary is available
-            binary = os.path.join(os.environ['DRAKE_DISTRO'], 'build/drake/automotive/maliput/utility/yaml_to_obj')
+            binary = os.path.join(os.environ['DRAKE_DISTRO'], 'bazel-bin/drake/automotive/maliput/utility/yaml_to_obj')
             monolane_file = self.path + self.base_name + '_monolane.yaml'
             params = "-yaml_file=\"{0}\" -obj_dir=\"{1}\" -obj_file=\"{2}\"".format(monolane_file, self.path, self.base_name + '_monolane')
             command = "{0} {1}".format(binary, params)

--- a/terminus/generate_test_cities.py
+++ b/terminus/generate_test_cities.py
@@ -40,7 +40,7 @@ class SampleBuilder(object):
     def name(self):
         return "SampleBuilder for {0}".format(self.city.name)
 
-test_cities = TestCitiesGenerator().all_cities()
+test_cities = TestCitiesGenerator().non_empty_cities()
 
 for city in test_cities:
     builder = SampleBuilder(city)

--- a/terminus/generators/monolane_generator.py
+++ b/terminus/generators/monolane_generator.py
@@ -15,11 +15,17 @@ limitations under the License.
 """
 
 from collections import OrderedDict
+import math
 
 import yaml
+from geometry.point import Point
+from geometry.line_segment import LineSegment
+from file_generator import FileGenerator
+from monolane_id_mapper import MonolaneIdMapper
 
-from .file_generator import FileGenerator
-from .monolane_id_mapper import MonolaneIdMapper
+import logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 class MonolaneGenerator(FileGenerator):
@@ -39,61 +45,135 @@ class MonolaneGenerator(FileGenerator):
                 ('driveable_bounds', [-4, 4]),
                 ('position_precision', 0.01),
                 ('orientation_precision', 0.5),
-                ('points', self.monolane_id_mapper.get_monolane_points()),
+                ('points', OrderedDict()),
                 ('connections', OrderedDict()),
                 ('groups', OrderedDict()),
             ])
         }
 
-    def point_name_by_road_node(self, road, node):
-        return self.monolane_id_mapper.point_name_by_road_node(road, node)
+    def start_lane(self, lane):
+        self._build_lane_points(lane)
+        self._build_lane_connections(lane)
 
-    def new_connection(self, node1, road1, node2, road2):
-        """Add a new monolane connection between two road nodes."""
-        # Get the point names using the road node combo.
-        # These names were created by the id mapper.
-        point1 = self.point_name_by_road_node(road1, node1)
-        point2 = self.point_name_by_road_node(road2, node2)
+    def _build_lane_connections(self, lane):
+        all_waypoints = lane.get_waypoints()
+        previous_waypoint = None
+        for waypoint in all_waypoints:
+            if previous_waypoint is not None:
+                # If the waypoint is an exit, create the connection with all the
+                # entry waypoints of the other lanes.
+                if waypoint.is_exit():
+                    for entry_waypoint in waypoint.connected_waypoints():
+                        monolane_connection = self._create_arc_connection(waypoint, entry_waypoint)
+                        if monolane_connection is not None:
+                            monolane_connection_id = "{0}-{1}".format(self.monolane_id_mapper.formatted_id_for(waypoint), self.monolane_id_mapper.formatted_id_for(entry_waypoint))
+                            self.monolane['maliput_monolane_builder']['connections'][monolane_connection_id] = monolane_connection
 
-        # Create a connection name using the two monolane point names.
-        connection_name = "{0}-{1}".format(point1, point2)
+                # Do the previous and current waypoint belong to the same intersection?
+                are_same_intersection = previous_waypoint.source_node == waypoint.source_node
 
-        # Create the new connection, explicitly starting with the first point,
-        # ending with the second point, and with a length equal to the distance
-        # between the points.
-        new_monolane_connection = {
-            connection_name: OrderedDict([
-                ('start',
-                    "points.{0}".format(self.point_name_by_road_node(road1, node1))),
-                ('length',
-                    node1.center.distance_to(node2.center)),
-                ('explicit_end',
-                    "points.{0}".format(self.point_name_by_road_node(road2, node2))),
-            ])
-        }
-        # Store the new connection in the monolane dictionary.
-        self.monolane['maliput_monolane_builder']['connections'].update(
-            new_monolane_connection)
+                # In some cases we don't want to generate the connection between
+                # the previous and following node.
+                # If the lane starts with an intersection, start on the entry waypoint
+                if are_same_intersection and previous_waypoint == all_waypoints[0] and waypoint.is_entry():
+                    pass
+                # If the lane ends with an intersection, end it on the exit waypoint
+                elif are_same_intersection and waypoint == all_waypoints[-1] and previous_waypoint.is_exit():
+                    pass
+                elif previous_waypoint.center == waypoint.center:
+                    pass
+                elif previous_waypoint.is_arc_start_connection() and waypoint.is_arc_end_connection():
+                    monolane_connection = self._create_arc_connection(previous_waypoint, waypoint)
+                    if monolane_connection is not None:
+                        monolane_connection_id = "{0}-{1}".format(self.monolane_id_mapper.formatted_id_for(previous_waypoint), self.monolane_id_mapper.formatted_id_for(waypoint))
+                        self.monolane['maliput_monolane_builder']['connections'][monolane_connection_id] = monolane_connection
+                else:
+                    monolane_connection = self._create_line_connection(previous_waypoint, waypoint)
+                    monolane_connection_id = "{0}-{1}".format(self.monolane_id_mapper.formatted_id_for(previous_waypoint), self.monolane_id_mapper.formatted_id_for(waypoint))
+                    self.monolane['maliput_monolane_builder']['connections'][monolane_connection_id] = monolane_connection
+            previous_waypoint = waypoint
 
-    def process_road(self, road):
-        """Called anytime a street or trunk are visited."""
-        previous_node = None
-        for node in road.get_nodes():
-            # If this is not the first node in the road, make a
-            # connection with the previous node.
-            if previous_node is not None:
-                self.new_connection(previous_node, road, node, road)
-            previous_node = node
+    def _create_line_connection(self, start_waypoint, end_waypoint):
+        return OrderedDict([
+            ('start', 'points.' + self.monolane_id_mapper.formatted_id_for(start_waypoint)),
+            ('length', start_waypoint.center.distance_to(end_waypoint.center)),
+            ('explicit_end', 'points.' + self.monolane_id_mapper.formatted_id_for(end_waypoint))
+        ])
 
-    def start_street(self, street):
-        self.process_road(street)
+    def _create_arc_connection(self, start_waypoint, end_waypoint):
+        try:
+            previous_waypoint = self._previous_waypoint(start_waypoint)
+            start_vector = start_waypoint.center - previous_waypoint.center
 
-    def start_trunk(self, trunk):
-        self.process_road(trunk)
+            following_waypoint = self._following_waypoint(end_waypoint)
+            end_vector = following_waypoint.center - end_waypoint.center
+        except:
+            logger.debug("Can't create arc connection between {0} and {1}".format(start_waypoint, end_waypoint))
+            return None
+
+        angle = start_vector.angle(end_vector)
+        d2 = start_waypoint.center.squared_distance_to(end_waypoint.center)
+        cos = math.cos(angle)
+        if cos == 1:
+            return None
+        radius = math.sqrt(d2 / (2 * (1 - cos)))
+
+        # If the turning radius is less than the driveable_bounds then
+        # don't generate the connection
+        if radius <= 4:
+            return None
+
+        angle_in_degrees = math.degrees(angle)
+
+        # Keep the angle in the [-180, 180) range
+        if angle_in_degrees >= 180:
+            angle_in_degrees = angle_in_degrees - 360
+
+        if angle_in_degrees < -180:
+            angle_in_degrees = angle_in_degrees + 360
+
+        return OrderedDict([
+            ('start', 'points.' + self.monolane_id_mapper.formatted_id_for(start_waypoint)),
+            ('arc', [radius, angle_in_degrees]),
+            ('explicit_end', 'points.' + self.monolane_id_mapper.formatted_id_for(end_waypoint))
+        ])
+
+    def _previous_waypoint(self, waypoint):
+        (road_id, lane_id, waypoint_id) = self.monolane_id_mapper.id_for(waypoint)
+        return self.monolane_id_mapper.object_for((road_id, lane_id, waypoint_id - 1))
+
+    def _following_waypoint(self, waypoint):
+        (road_id, lane_id, waypoint_id) = self.monolane_id_mapper.id_for(waypoint)
+        return self.monolane_id_mapper.object_for((road_id, lane_id, waypoint_id + 1))
 
     def end_document(self):
         """Called after the document is generated, but before it is written to a file."""
         self.document.write(self.to_string())
+
+    def _build_lane_points(self, lane):
+        previous_waypoint = None
+        previous_monolane_point = None
+        last_line_heading = None
+        for waypoint in lane.get_waypoints():
+            monolane_point = self._monolane_point_from_waypoint(waypoint)
+            monolane_point_id = self.monolane_id_mapper.formatted_id_for(waypoint)
+            self.monolane['maliput_monolane_builder']['points'][monolane_point_id] = monolane_point
+            if previous_waypoint is not None:
+                if previous_waypoint.is_arc_start_connection() and waypoint.is_arc_end_connection():
+                    if last_line_heading is not None:
+                        previous_monolane_point['xypoint'][2] = last_line_heading
+                else:
+                    previous_heading = math.degrees(previous_waypoint.center.yaw(waypoint.center))
+                    last_line_heading = previous_heading
+                    previous_monolane_point['xypoint'][2] = previous_heading
+            previous_waypoint = waypoint
+            previous_monolane_point = monolane_point
+
+    def _monolane_point_from_waypoint(self, waypoint):
+        point = OrderedDict()
+        point['xypoint'] = [float(waypoint.center.x), float(waypoint.center.y), 0]
+        point['zpoint'] = [float(waypoint.center.z), 0, 0, 0]
+        return point
 
     def to_string(self, Dumper=yaml.Dumper, **kwds):
         """Convert the current monolane data into its yaml version.

--- a/terminus/generators/monolane_id_mapper.py
+++ b/terminus/generators/monolane_id_mapper.py
@@ -14,121 +14,55 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from collections import OrderedDict
-from math import degrees
-
 from city_visitor import CityVisitor
 from models.road_intersection_node import RoadIntersectionNode
 
 
 class MonolaneIdMapper(CityVisitor):
-    """Simple city visitor that generates the Monolane point names ("id's").
-
-    This class refers to "road nodes", which in this case is a unique
-    combination of a road (a street or a trunk) with a node.
-    The node might be a RoadIntersectionNode, in which case the node might
-    be associated with more than one road.
-    For the purposes of Monolane, this is not OK, so we create a point name per
-    road-node pair.
-    """
+    # TODO: Code is almost the same as the RNDF id mapper. Refactor.
 
     def run(self):
-        self.point_name_by_road_node_dict = {}
-        self.intersection_index = 0
-        self.intersection_index_by_node = {}
-        self.monolane_points = OrderedDict()
+        self.lane_id = 0
+        self.waypoint_id = 0
+        self.object_to_id_level_1 = {}
+        self.object_to_id_level_2 = {}
+        self.id_to_object = {}
         super(MonolaneIdMapper, self).run()
 
-    def road_node_id(self, road, node):
-        """Return a hashable unique identifier for a road node."""
-        return (road.name, id(node))
+    def id_for(self, object):
+        try:
+            return self.object_to_id_level_1[id(object)]
+        except KeyError:
+            return self.object_to_id_level_2[object]
 
-    def get_monolane_points(self):
-        return self.monolane_points
+    def formatted_id_for(self, object):
+        id = self.id_for(object)
+        return "{0}_{1}_{2}".format(id[0], id[1], id[2])
 
-    def point_name_by_road_node(self, road, node):
-        return self.point_name_by_road_node_dict[self.road_node_id(road, node)][0]
+    def object_for(self, id):
+        return self.id_to_object[id]
 
-    def process_road(self, road):
-        """Called anytime a road or trunk are visited.
-
-        Each node in the road is given a unique monolane point name which is
-        based on both the node and the road name.
-        It takes this form:
-
-            <road.name>-<point_index>[-from_Intersection-<intersection_index>]
-
-        The ``point_index`` is unique within a single road, i.e. it is reset
-        each time a new road is processed.
-        The optional suffix is added if the node is a ``RoadIntersectionNode``.
-        The optional suffix uses ``intersection_index`` which is the unique
-        number associated with each ``RoadIntersectionNode`` in the city.
-        """
-        # Iterate over all of the nodes in the road, given them unique
-        # monolane point names, and store them for later use.
-        point_index = 1  # used to uniquely name the points for this road
-        previous_point_name = None
-        previous_point_center = None
-        previous_heading = 0
-        for node in list(road.get_nodes()):
-            # Generate a unique name for the point based on the road name.
-            point_name = '{}-{}'.format(road.name, point_index)
-            point_index += 1
-            # If this is an "RoadIntersectionNode", adjust the name to indicate it.
-            if isinstance(node, RoadIntersectionNode):
-                # Get the index associated with the intersection.
-                if id(node) not in self.intersection_index_by_node:
-                    # Assign an index if this is the first appearance.
-                    self.intersection_index_by_node[id(node)] = self.intersection_index
-                    self.intersection_index += 1
-                index = self.intersection_index_by_node[id(node)]
-                # Adjust the name to include the intersection.
-                point_name = '{}-from_Intersection-{}'.format(point_name, index)
-            # Get a unique and hash-able identifier for the road node.
-            node_ident = self.road_node_id(road, node)
-            # Ensure it is unique.
-            if node_ident in self.point_name_by_road_node_dict:
-                raise RuntimeError("Non-unique road node identifier. This should not happen.")
-            # Store the point name using the identifier.
-            self.point_name_by_road_node_dict[node_ident] = (point_name, node)
-            # Put the point into the monolane dictionary.
-            new_monolane_point = {
-                point_name: OrderedDict([
-                    ('xypoint', [  # x, y, heading
-                        float(node.center.x),
-                        float(node.center.y),
-                        0  # will be set later using heading between this point and the next
-                    ]),
-                    ('zpoint', [  # z, zdot, theta (superelevation), thetadot
-                        float(node.center.z),
-                        0,
-                        0,
-                        0
-                    ]),
-                ])
-            }
-            # If there was a previous point, calculate the heading from it to this point.
-            if previous_point_name is not None:
-                # Get the previous point's center by name.
-                previous_point = self.monolane_points[previous_point_name]['xypoint']
-                # Calculate the heading.
-                previous_heading = degrees(previous_point_center.yaw(node.center))
-                # Store it.
-                previous_point[2] = previous_heading
-            previous_point_name = point_name
-            previous_point_center = node.center
-            # Insert the new point.
-            self.monolane_points.update(new_monolane_point)
-        # end for node in list(road.get_nodes())
-
-        # Update the heading of the last point (last one processed in the for loop).
-        if previous_point_name is not None:
-            # Use the last heading as the heading of the last point.
-            previous_point = self.monolane_points[previous_point_name]['xypoint']
-            previous_point[2] = previous_heading
+    def map_road(self, road):
+        self.road_id = road.name
+        self.lane_id = 0
 
     def start_street(self, street):
-        self.process_road(street)
+        self.map_road(street)
 
     def start_trunk(self, trunk):
-        self.process_road(trunk)
+        self.map_road(trunk)
+
+    def start_lane(self, lane):
+        self.lane_id = self.lane_id + 1
+        self.waypoint_id = 0
+        for waypoint in lane.get_waypoints():
+            self.waypoint_id = self.waypoint_id + 1
+            waypoint_uid = (self.road_id, self.lane_id, self.waypoint_id)
+            self._register(waypoint_uid, waypoint)
+
+    def _register(self, object_id, object):
+        """We do some caching by id, to avoid computing hashes if they are
+        expensive, but keep the hash-based dict as a fallback"""
+        self.object_to_id_level_1[id(object)] = object_id
+        self.object_to_id_level_2[object] = object_id
+        self.id_to_object[object_id] = object

--- a/terminus/geometry/point.py
+++ b/terminus/geometry/point.py
@@ -65,8 +65,17 @@ class Point(object):
     def dot_product(self, other):
         return self.x * other.x + self.y * other.y + self.z * other.z
 
+    def angle(self, other):
+        v1 = self.normalized()
+        v2 = other.normalized()
+        return math.atan2(v2.y, v2.x) - math.atan2(v1.y, v1.x)
+
     def norm(self):
         return math.sqrt(self.x ** 2 + self.y ** 2 + self.z ** 2)
+
+    def normalized(self):
+        length = self.norm()
+        return Point(self.x / length, self.y / length, self.z / length)
 
     def squared_distance_to(self, other):
         return (self.x - other.x) ** 2 + (self.y - other.y) ** 2 + (self.z - other.z) ** 2

--- a/terminus/models/lane_intersection_node.py
+++ b/terminus/models/lane_intersection_node.py
@@ -38,25 +38,48 @@ class LaneIntersectionNode(LaneNode):
         predecessor = lane.previous_node(lane_node)
         successor = lane.following_node(lane_node)
 
+        has_predecessor = predecessor is not None
+        has_successor = successor is not None
+
         requires_exit_waypoint = any(other_lane.following_node(lane_node) is not None for other_lane in lane_node.involved_lanes_except(lane))
         requires_entry_waypoint = any(other_lane.previous_node(lane_node) is not None for other_lane in lane_node.involved_lanes_except(lane))
 
-        add_exit_waypoint = requires_exit_waypoint and predecessor is not None
-        add_entry_waypoint = requires_entry_waypoint and successor is not None
+        if has_predecessor and has_successor:
+            predecessor_vector = self.center - predecessor.center
+            successor_vector = successor.center - self.center
+            are_segments_colinear = predecessor_vector.cross_product(successor_vector) == Point(0.0, 0.0, 0.0)
+            delta = min((predecessor_vector.norm() / 2.0) - 0.1, (successor_vector.norm() / 2.0) - 0.1, 5)
+        else:
+            are_segments_colinear = True
+            if has_predecessor:
+                predecessor_vector = self.center - predecessor.center
+                delta = min((predecessor_vector.norm() / 2.0) - 0.1, 5)
+            elif has_successor:
+                successor_vector = successor.center - self.center
+                delta = min((successor_vector.norm() / 2.0) - 0.1, 5)
 
-        if add_exit_waypoint:
-            point = LineString([lane_node.center.to_shapely_point(), predecessor.center.to_shapely_point()]).interpolate(5)
+        add_predecessor_waypoint = has_predecessor and (requires_exit_waypoint or not are_segments_colinear)
+        add_successor_waypoint = has_successor and (requires_entry_waypoint or not are_segments_colinear)
+
+        if add_predecessor_waypoint:
+            point = LineString([lane_node.center.to_shapely_point(), predecessor.center.to_shapely_point()]).interpolate(delta)
             waypoint = Waypoint(lane, lane_node, Point.from_shapely(point))
-            waypoint.be_exit()
+            if requires_exit_waypoint:
+                waypoint.be_exit()
+            if has_successor and not are_segments_colinear:
+                waypoint.be_arc_start_connection()
             waypoints.append(waypoint)
 
-        if (not add_entry_waypoint or not add_exit_waypoint):
+        if (not add_predecessor_waypoint or not add_successor_waypoint):
             waypoints.append(Waypoint(lane, lane_node, lane_node.center))
 
-        if add_entry_waypoint:
-            point = LineString([lane_node.center.to_shapely_point(), successor.center.to_shapely_point()]).interpolate(5)
+        if add_successor_waypoint:
+            point = LineString([lane_node.center.to_shapely_point(), successor.center.to_shapely_point()]).interpolate(delta)
             waypoint = Waypoint(lane, lane_node, Point.from_shapely(point))
-            waypoint.be_entry()
+            if requires_entry_waypoint:
+                waypoint.be_entry()
+            if has_predecessor and not are_segments_colinear:
+                waypoint.be_arc_end_connection()
             waypoints.append(waypoint)
 
         return waypoints
@@ -71,4 +94,4 @@ class LaneIntersectionNode(LaneNode):
         return connections
 
     def __repr__(self):
-        return "LaneIntersectionNode @ " + str(self.center)
+        return "LaneIntersectionNode @ " + str(self.center) + " " + str(self.source)

--- a/terminus/models/lane_simple_node.py
+++ b/terminus/models/lane_simple_node.py
@@ -16,6 +16,9 @@ limitations under the License.
 
 from lane_node import LaneNode
 from waypoint import Waypoint
+from geometry.point import Point
+from geometry.line_segment import LineSegment
+from shapely.geometry import LineString
 
 
 class LaneSimpleNode(LaneNode):
@@ -33,10 +36,37 @@ class LaneSimpleNode(LaneNode):
     def get_waypoints_for(self, lane):
         if (self.lane is not lane):
             return None
-        return [Waypoint(lane, self, self.center)]
+
+        previous_node = lane.previous_node(self)
+        following_node = lane.following_node(self)
+        if previous_node is None or following_node is None:
+            return [Waypoint(lane, self, self.center)]
+        else:
+            previous_vector = self.center - previous_node.center
+            following_vector = following_node.center - self.center
+            # If they are colinear
+            if previous_vector.cross_product(following_vector) == Point(0.0, 0.0, 0.0):
+                return [Waypoint(lane, self, self.center)]
+            else:
+                previous_segment = LineSegment(previous_node.center, self.center)
+                following_segment = LineSegment(following_node.center, self.center)
+
+                delta = min((previous_segment.length() / 2.0) - 0.1, (following_segment.length() / 2.0) - 0.1, 5)
+
+                point = LineString([self.center.to_shapely_point(), previous_node.center.to_shapely_point()]).interpolate(delta)
+                previous_waypoint_center = Point.from_shapely(point)
+                previous_waypoint = Waypoint(lane, self, previous_waypoint_center)
+                previous_waypoint.be_arc_start_connection()
+
+                point = LineString([self.center.to_shapely_point(), following_node.center.to_shapely_point()]).interpolate(delta)
+                following_waypoint_center = Point.from_shapely(point)
+                following_waypoint = Waypoint(lane, self, following_waypoint_center)
+                following_waypoint.be_arc_end_connection()
+
+        return [previous_waypoint, following_waypoint]
 
     def connected_waypoints_for(self, waypoint):
         return []
 
     def __repr__(self):
-        return "LaneSimpleNode @ " + str(self.center)
+        return "LaneSimpleNode @ " + str(self.center) + " " + str(self.source)

--- a/terminus/models/road.py
+++ b/terminus/models/road.py
@@ -103,7 +103,10 @@ class Road(CityModel):
         old_node.removed_from(self)
 
     def includes_point(self, point):
-        return point in self._point_to_node
+        # Attempt a constant search in the points dictionary. If that fails
+        # do the linear search in the nodes collection.
+        return (point in self._point_to_node) or \
+            any(node.center.almost_equal_to(point, 5) for node in self._nodes)
 
     def reverse(self):
         self._nodes.reverse()

--- a/terminus/models/waypoint.py
+++ b/terminus/models/waypoint.py
@@ -23,6 +23,7 @@ class Waypoint(object):
         self.source_node = source_node
         self.center = center
         self.be_reference()
+        self.be_line_connection()
 
     @classmethod
     def entry(cls, lane, source_node, center):
@@ -35,6 +36,8 @@ class Waypoint(object):
         waypoint = cls(lane, source_node, center)
         waypoint.be_exit()
         return waypoint
+
+    # Logical type
 
     def is_exit(self):
         return self.type.is_exit()
@@ -50,6 +53,26 @@ class Waypoint(object):
 
     def be_reference(self):
         self.type = ReferencePoint()
+
+    # Geometrical type
+
+    def be_line_connection(self):
+        self.connection_type = 'Line'
+
+    def be_arc_start_connection(self):
+        self.connection_type = 'ArcBegin'
+
+    def be_arc_end_connection(self):
+        self.connection_type = 'ArcEnd'
+
+    def is_line_connection(self):
+        return self.connection_type == 'Line'
+
+    def is_arc_start_connection(self):
+        return self.connection_type == 'ArcBegin'
+
+    def is_arc_end_connection(self):
+        return self.connection_type == 'ArcEnd'
 
     def connected_waypoints(self):
         return self.source_node.connected_waypoints_for(self)
@@ -68,7 +91,7 @@ class Waypoint(object):
         return hash((self.type, self.center, self.lane, self.source_node))
 
     def __repr__(self):
-        return str(self.type) + "Waypoint at " + str(self.center) + \
+        return str(self.type) + self.connection_type + " Waypoint at " + str(self.center) + \
             ". Source node " + str(self.source_node)
 
 

--- a/terminus/tests/lane_test.py
+++ b/terminus/tests/lane_test.py
@@ -521,24 +521,24 @@ class LaneTest(unittest.TestCase):
 
         expected_waypoints_lane_1 = [
             Waypoint(horizontal_lane_1, horizontal_lane_1_nodes[0], Point(-1000, -2)),
-            Waypoint.exit(horizontal_lane_1, horizontal_lane_1_nodes[1], Point(-7, -2)),
-            Waypoint.exit(horizontal_lane_1, horizontal_lane_1_nodes[2], Point(-2, -2)),
-            Waypoint.entry(horizontal_lane_1, horizontal_lane_1_nodes[1], Point(2, -2)),
-            Waypoint.entry(horizontal_lane_1, horizontal_lane_1_nodes[2], Point(7, -2)),
+            Waypoint.exit(horizontal_lane_1, horizontal_lane_1_nodes[1], Point(-3.9, -2)),
+            Waypoint.entry(horizontal_lane_1, horizontal_lane_1_nodes[1], Point(-0.1, -2)),
+            Waypoint.exit(horizontal_lane_1, horizontal_lane_1_nodes[2], Point(0.1, -2)),
+            Waypoint.entry(horizontal_lane_1, horizontal_lane_1_nodes[2], Point(3.9, -2)),
             Waypoint(horizontal_lane_1, horizontal_lane_1_nodes[3], Point(1000, -2))
         ]
 
         expected_waypoints_lane_2 = [
             Waypoint(horizontal_lane_2, horizontal_lane_2_nodes[0], Point(-1000, 2)),
-            Waypoint.exit(horizontal_lane_2, horizontal_lane_2_nodes[1], Point(-7, 2)),
-            Waypoint.exit(horizontal_lane_2, horizontal_lane_2_nodes[2], Point(-2, 2)),
-            Waypoint.entry(horizontal_lane_2, horizontal_lane_2_nodes[1], Point(2, 2)),
-            Waypoint.entry(horizontal_lane_2, horizontal_lane_2_nodes[2], Point(7, 2)),
+            Waypoint.exit(horizontal_lane_2, horizontal_lane_2_nodes[1], Point(-3.9, 2)),
+            Waypoint.entry(horizontal_lane_2, horizontal_lane_2_nodes[1], Point(-0.1, 2)),
+            Waypoint.exit(horizontal_lane_2, horizontal_lane_2_nodes[2], Point(0.1, 2)),
+            Waypoint.entry(horizontal_lane_2, horizontal_lane_2_nodes[2], Point(3.9, 2)),
             Waypoint(horizontal_lane_2, horizontal_lane_2_nodes[3], Point(1000, 2))
         ]
 
-        self.assertEquals(expected_waypoints_lane_1, horizontal_lane_1.get_waypoints())
-        self.assertEquals(expected_waypoints_lane_2, horizontal_lane_2.get_waypoints())
+        self.assertWaypointCollectionsAreAlmostEquals(expected_waypoints_lane_1, horizontal_lane_1.get_waypoints())
+        self.assertWaypointCollectionsAreAlmostEquals(expected_waypoints_lane_2, horizontal_lane_2.get_waypoints())
 
     def test_get_waypoints_single_intersection_two_lanes_overlapping(self):
         '''
@@ -575,24 +575,24 @@ class LaneTest(unittest.TestCase):
 
         expected_waypoints_lane_1 = [
             Waypoint(horizontal_lane_1, horizontal_lane_1_nodes[0], Point(-1000, -5)),
-            Waypoint.exit(horizontal_lane_1, horizontal_lane_1_nodes[1], Point(-10, -5)),
-            Waypoint.entry(horizontal_lane_1, horizontal_lane_1_nodes[1], Point(0, -5)),
-            Waypoint.exit(horizontal_lane_1, horizontal_lane_1_nodes[2], Point(0, -5)),
-            Waypoint.entry(horizontal_lane_1, horizontal_lane_1_nodes[2], Point(10, -5)),
+            Waypoint.exit(horizontal_lane_1, horizontal_lane_1_nodes[1], Point(-9.9, -5)),
+            Waypoint.entry(horizontal_lane_1, horizontal_lane_1_nodes[1], Point(-0.1, -5)),
+            Waypoint.exit(horizontal_lane_1, horizontal_lane_1_nodes[2], Point(0.1, -5)),
+            Waypoint.entry(horizontal_lane_1, horizontal_lane_1_nodes[2], Point(9.9, -5)),
             Waypoint(horizontal_lane_1, horizontal_lane_1_nodes[3], Point(1000, -5))
         ]
 
         expected_waypoints_lane_2 = [
             Waypoint(horizontal_lane_2, horizontal_lane_2_nodes[0], Point(-1000, 5)),
-            Waypoint.exit(horizontal_lane_2, horizontal_lane_2_nodes[1], Point(-10, 5)),
-            Waypoint.entry(horizontal_lane_2, horizontal_lane_2_nodes[1], Point(0, 5)),
-            Waypoint.exit(horizontal_lane_2, horizontal_lane_2_nodes[2], Point(0, 5)),
-            Waypoint.entry(horizontal_lane_2, horizontal_lane_2_nodes[2], Point(10, 5)),
+            Waypoint.exit(horizontal_lane_2, horizontal_lane_2_nodes[1], Point(-9.9, 5)),
+            Waypoint.entry(horizontal_lane_2, horizontal_lane_2_nodes[1], Point(-0.1, 5)),
+            Waypoint.exit(horizontal_lane_2, horizontal_lane_2_nodes[2], Point(0.1, 5)),
+            Waypoint.entry(horizontal_lane_2, horizontal_lane_2_nodes[2], Point(9.9, 5)),
             Waypoint(horizontal_lane_2, horizontal_lane_2_nodes[3], Point(1000, 5))
         ]
 
-        self.assertEquals(expected_waypoints_lane_1, horizontal_lane_1.get_waypoints())
-        self.assertEquals(expected_waypoints_lane_2, horizontal_lane_2.get_waypoints())
+        self.assertWaypointCollectionsAreAlmostEquals(expected_waypoints_lane_1, horizontal_lane_1.get_waypoints())
+        self.assertWaypointCollectionsAreAlmostEquals(expected_waypoints_lane_2, horizontal_lane_2.get_waypoints())
 
     def test_get_waypoints_single_intersection_two_lanes_big_offset(self):
         '''
@@ -772,6 +772,13 @@ class LaneTest(unittest.TestCase):
             Waypoint(horizontal_lane_2, lane_nodes[2], Point(1000, 7)),
         ]
         self.assertEquals(expected_waypoints, horizontal_lane_2.get_waypoints())
+
+    def assertWaypointCollectionsAreAlmostEquals(self, collection1, collection2):
+        for waypoint1, waypoint2 in zip(collection1, collection2):
+            self.assertPointsAreAlmostEquals(waypoint1.center, waypoint2.center)
+            self.assertEquals(waypoint1.type, waypoint2.type)
+            self.assertEquals(waypoint1.lane, waypoint2.lane)
+            self.assertEquals(waypoint1.source_node, waypoint2.source_node)
 
     def assertPointCollectionsAreAlmostEquals(self, collection1, collection2):
         if (len(collection1) != len(collection2)):

--- a/terminus/tests/monolane_generator_test.py
+++ b/terminus/tests/monolane_generator_test.py
@@ -68,45 +68,29 @@ class MonolaneGeneratorTest(unittest.TestCase):
 
         monolane_dict = self.generate_monolane(city)
 
-        self.assertEqual(6, len(monolane_dict['points']))
-        self.assertEqual(4, len(monolane_dict['connections']))
-        # Make sure two of the points are part of the intersection.
-        self.assertEqual(2, len([x for x in monolane_dict['points'] if 'Intersection' in x]))
-        # Make sure there is only one intersection, i.e. no Intersection-2, only Intersection-1.
-        self.assertFalse(any([x for x in monolane_dict['points'] if 'Intersection-2' in x]))
+        self.assertEqual(8, len(monolane_dict['points']))
+        self.assertEqual(8, len(monolane_dict['connections']))
 
     def test_L_intersection(self):
         city = self.test_generator.L_intersection_city()
 
         monolane_dict = self.generate_monolane(city)
 
-        self.assertEqual(4, len(monolane_dict['points']))
-        self.assertEqual(2, len(monolane_dict['connections']))
-        # Make sure two of the points are part of the intersection.
-        self.assertEqual(2, len([x for x in monolane_dict['points'] if 'Intersection' in x]))
-        # Make sure there is only one intersection, i.e. no Intersection-2, only Intersection-1.
-        self.assertFalse(any([x for x in monolane_dict['points'] if 'Intersection-2' in x]))
+        self.assertEqual(6, len(monolane_dict['points']))
+        self.assertEqual(3, len(monolane_dict['connections']))
 
     def test_Y_intersection_one_to_many(self):
         city = self.test_generator.Y_intersection_one_to_many_city()
 
         monolane_dict = self.generate_monolane(city)
 
-        self.assertEqual(6, len(monolane_dict['points']))
-        self.assertEqual(3, len(monolane_dict['connections']))
-        # Make sure two of the points are part of the intersection.
-        self.assertEqual(3, len([x for x in monolane_dict['points'] if 'Intersection' in x]))
-        # Make sure there is only one intersection, i.e. no Intersection-2, only Intersection-1.
-        self.assertFalse(any([x for x in monolane_dict['points'] if 'Intersection-2' in x]))
+        self.assertEqual(9, len(monolane_dict['points']))
+        self.assertEqual(5, len(monolane_dict['connections']))
 
     def test_Y_intersection_many_to_one(self):
         city = self.test_generator.Y_intersection_many_to_one_city()
 
         monolane_dict = self.generate_monolane(city)
 
-        self.assertEqual(6, len(monolane_dict['points']))
-        self.assertEqual(3, len(monolane_dict['connections']))
-        # Make sure two of the points are part of the intersection.
-        self.assertEqual(3, len([x for x in monolane_dict['points'] if 'Intersection' in x]))
-        # Make sure there is only one intersection, i.e. no Intersection-2, only Intersection-1.
-        self.assertFalse(any([x for x in monolane_dict['points'] if 'Intersection-2' in x]))
+        self.assertEqual(9, len(monolane_dict['points']))
+        self.assertEqual(5, len(monolane_dict['connections']))

--- a/terminus/tests/test_cities_generator.py
+++ b/terminus/tests/test_cities_generator.py
@@ -46,9 +46,11 @@ class TestCitiesGenerator(object):
 
     def cross_intersection_city(self):
         """
-             (0,1)
-        (-1,0) + (1,0)
-             (0,-1)
+                   (0,100)
+                     |
+        (-100,0) -- + -- (100,0)
+                     |
+                   (0,-100)
         """
         city = City("Cross")
 
@@ -65,10 +67,50 @@ class TestCitiesGenerator(object):
 
         return city
 
+    def non_collinear_segments_city(self):
+        """
+        (-100,0) -- (0,0) -- (100,30)
+        """
+        city = City("NonCollinearSegments")
+
+        s1 = Street.from_points([Point(-100, 0), Point(0, 0), Point(100, 30)])
+        s1.name = "s1"
+
+        city.add_road(s1)
+
+        return city
+
+    def two_non_collinear_segments_border_city(self):
+        """
+        (-10,0) -- (0,0) -- (10,2) -- (20,4)
+        """
+        city = City("NonCollinearSegmentsBorder")
+
+        s1 = Street.from_points([Point(-10, 0), Point(0, 0), Point(10, 2), Point(20, 7)])
+        s1.name = "s1"
+
+        city.add_road(s1)
+
+        return city
+
+    def two_non_collinear_segments_less_than_border_city(self):
+        """
+        (-10,0) -- (0,0) -- (10,2) -- (20,4)
+        """
+        city = City("NonCollinearSegmentsLessThanBorder")
+
+        s1 = Street.from_points([Point(-10, 0), Point(0, 0), Point(4, 2), Point(20, 7)])
+        s1.name = "s1"
+
+        city.add_road(s1)
+
+        return city
+
     def L_intersection_city(self):
         """
-             (0,1)
-               +  (1,0)
+            (0,100)
+               |
+               + -- (100,0)
         """
         city = City("LCross")
 
@@ -85,11 +127,57 @@ class TestCitiesGenerator(object):
 
         return city
 
+    def T_intersection_out_city(self):
+        """
+        (-100,0) -- + -- (100,0)
+                    |
+                  (0,-100)
+        """
+        city = City("TIntersectionOut")
+
+        s1 = Street.from_points([Point(-100, 0), Point(0, 0), Point(100, 0)])
+        s1.name = "s1"
+
+        s2 = Street.from_points([Point(0, 0), Point(0, -100)])
+        s2.name = "s2"
+
+        city.add_intersection_at(Point(0, 0))
+
+        city.add_road(s1)
+        city.add_road(s2)
+
+        return city
+
+    def T_intersection_in_city(self):
+        """
+        (-100,0) -- + -- (100,0)
+                    |
+                  (0,-100)
+        """
+        city = City("TIntersectionIn")
+
+        s1 = Street.from_points([Point(-100, 0), Point(0, 0), Point(100, 0)])
+        s1.name = "s1"
+
+        s2 = Street.from_points([Point(0, -100), Point(0, 0)])
+        s2.name = "s2"
+
+        city.add_intersection_at(Point(0, 0))
+
+        city.add_road(s1)
+        city.add_road(s2)
+
+        return city
+
     def Y_intersection_one_to_many_city(self):
         """
-                  (0,1)
+                  (0,100)
+                    |
+                    |
                     +
-            (-1,-1)   (1,-1)
+                   / \
+                  /   \
+         (-100,-100) (100,-100)
         """
         city = City("YCross")
 
@@ -112,9 +200,13 @@ class TestCitiesGenerator(object):
 
     def Y_intersection_many_to_one_city(self):
         """
-                  (0,1)
+                  (0,100)
+                    |
+                    |
                     +
-            (-1,-1)   (1,-1)
+                   / \
+                  /   \
+         (-100,-100) (100,-100)
         """
         city = City("YCross Many to One")
 

--- a/terminus/tests/test_cities_generator.py
+++ b/terminus/tests/test_cities_generator.py
@@ -21,7 +21,7 @@ from models.street import Street
 
 class TestCitiesGenerator(object):
 
-    def all_cities(self):
+    def non_empty_cities(self):
         cities = []
         for element in dir(self):
             attribute = getattr(self, element)

--- a/terminus/tests/vertex_graph_to_roads_converter_test.py
+++ b/terminus/tests/vertex_graph_to_roads_converter_test.py
@@ -326,29 +326,29 @@ class VertexGraphToRoadsConverterTest(unittest.TestCase):
         ]
         self.assertItemsEqual(self.city.roads, expected_roads)
 
-    def test_get_roads_pipe_trunk_into_street(self):
-        """
-        (0,0)(trunk)--(1,0)(trunk)--(6,0)
-        Expected: trunk:[(0,0),(1,0)]
-                  access street:[(6,0),(1,0)]
-        """
-        n1 = GraphNode(Point(0, 0))
-        n1.is_minor_road = False  # make trunk
-        n2 = GraphNode(Point(1, 0))
-        n2.is_minor_road = False  # make trunk
-        n3 = GraphNode(Point(6, 0))
+    # def test_get_roads_pipe_trunk_into_street(self):
+    #     """
+    #     (0,0)(trunk)--(1,0)(trunk)--(6,0)
+    #     Expected: trunk:[(0,0),(1,0)]
+    #               access street:[(6,0),(1,0)]
+    #     """
+    #     n1 = GraphNode(Point(0, 0))
+    #     n1.is_minor_road = False  # make trunk
+    #     n2 = GraphNode(Point(1, 0))
+    #     n2.is_minor_road = False  # make trunk
+    #     n3 = GraphNode(Point(6, 0))
 
-        self._connect(n1, n2)
-        self._connect(n2, n3)
+    #     self._connect(n1, n2)
+    #     self._connect(n2, n3)
 
-        VertexGraphToRoadsConverter(self.city, 0.25, [n1, n2, n3]).run()
+    #     VertexGraphToRoadsConverter(self.city, 0.25, [n1, n2, n3]).run()
 
-        intersection = RoadIntersectionNode.on(1, 0)
-        expected_roads = [
-            Street.from_nodes([RoadSimpleNode.on(6, 0), intersection]),
-            Trunk.from_nodes([RoadSimpleNode.on(0, 0), intersection])
-        ]
-        self.assertItemsEqual(self.city.roads, expected_roads)
+    #     intersection = RoadIntersectionNode.on(1, 0)
+    #     expected_roads = [
+    #         Street.from_nodes([RoadSimpleNode.on(6, 0), intersection]),
+    #         Trunk.from_nodes([RoadSimpleNode.on(0, 0), intersection])
+    #     ]
+    #     self.assertItemsEqual(self.city.roads, expected_roads)
 
     def _connect(self, n1, n2):
         """Make a bidirectional connection between two nodes"""


### PR DESCRIPTION
This PR is a first shot at generating valid monolane files for our models. To do so two main enhancements are implemented:

- Generate arcs to connect intersecting streets.
- Generate arcs to connect two segments of the same street if they are not collinear.

Aside from that, this PR includes the following changes:
- Removed Trunk generation / rendering as that would require some further changes to work with monolane.
- Added SVG / yaml_to_obj automatic conversion (if the binaries are available) when passing the `--debug` flag.


Below there are some test samples:

![monolane_samples](https://cloud.githubusercontent.com/assets/4070228/23753795/82b44adc-04b9-11e7-939e-821f407a0c7b.png)


Monolane file for simple city. Note that the 45 degree corner is not generated as the radius would be smaller than 4 meters. This will be addressed in a separate issue.

![simple_city](https://cloud.githubusercontent.com/assets/4070228/23753834/a825b22e-04b9-11e7-852b-5a3e62476443.png)

Monolane for OSM `small_paris` file:

![small_paris](https://cloud.githubusercontent.com/assets/4070228/23753861/bd0da052-04b9-11e7-8e70-94774fbad0c9.png)

Monolane for OSM `mcity` file:

![mcity](https://cloud.githubusercontent.com/assets/4070228/23753883/d153ec74-04b9-11e7-82ca-ca91d4259701.png)

