### PR TITLE
Add support for trimming redundant nodes in roads 

### DIFF
--- a/terminus/builders/osm_city_builder.py
+++ b/terminus/builders/osm_city_builder.py
@@ -107,6 +107,8 @@ class OsmCityBuilder(AbstractCityBuilder):
         self._create_roads(city)
         self._create_buildings(city)
 
+        city.trim_roads()
+
         return city
 
     def _get_ways(self, ways):

--- a/terminus/geometry/line_segment.py
+++ b/terminus/geometry/line_segment.py
@@ -29,7 +29,7 @@ class LineSegment(object):
         return cls(Point.from_tuple(t1), Point.from_tuple(t2))
 
     def includes_point(self, point, buffer=0.001):
-        # First check if the a->b and a->point are colinear. If they are,
+        # First check if the a->b and a->point are collinear. If they are,
         # the cross product should be zero (with some buffer for errors)
         cross_product = (self.b - self.a).cross_product(point - self.a)
         if cross_product.norm() > buffer:

--- a/terminus/models/city.py
+++ b/terminus/models/city.py
@@ -49,6 +49,12 @@ class City(CityModel):
     def roads_count(self):
         return len(self.roads)
 
+    def trim_roads(self):
+        # Based on current tests, having a 1 deg angle tolerance seems to
+        # give good results
+        for road in self.roads:
+            road.trim_redundant_nodes(1.0)
+
     def add_block(self, block):
         self.blocks.append(block)
 

--- a/terminus/models/lane_intersection_node.py
+++ b/terminus/models/lane_intersection_node.py
@@ -50,10 +50,10 @@ class LaneIntersectionNode(LaneNode):
         if has_predecessor and has_successor:
             predecessor_vector = self.center - predecessor.center
             successor_vector = successor.center - self.center
-            are_segments_colinear = predecessor_vector.cross_product(successor_vector) == Point(0.0, 0.0, 0.0)
+            are_segments_collinear = predecessor_vector.cross_product(successor_vector) == Point(0.0, 0.0, 0.0)
             delta = min((predecessor_vector.norm() / 2.0) - 0.1, (successor_vector.norm() / 2.0) - 0.1, 5)
         else:
-            are_segments_colinear = True
+            are_segments_collinear = True
             if has_predecessor:
                 predecessor_vector = self.center - predecessor.center
                 delta = min((predecessor_vector.norm() / 2.0) - 0.1, 5)
@@ -61,15 +61,15 @@ class LaneIntersectionNode(LaneNode):
                 successor_vector = successor.center - self.center
                 delta = min((successor_vector.norm() / 2.0) - 0.1, 5)
 
-        add_predecessor_waypoint = has_predecessor and (requires_exit_waypoint or not are_segments_colinear)
-        add_successor_waypoint = has_successor and (requires_entry_waypoint or not are_segments_colinear)
+        add_predecessor_waypoint = has_predecessor and (requires_exit_waypoint or not are_segments_collinear)
+        add_successor_waypoint = has_successor and (requires_entry_waypoint or not are_segments_collinear)
 
         if add_predecessor_waypoint:
             point = LineString([lane_node.center.to_shapely_point(), predecessor.center.to_shapely_point()]).interpolate(delta)
             waypoint = Waypoint(lane, lane_node, Point.from_shapely(point))
             if requires_exit_waypoint:
                 waypoint.be_exit()
-            if has_successor and not are_segments_colinear:
+            if has_successor and not are_segments_collinear:
                 waypoint.be_arc_start_connection()
             waypoints.append(waypoint)
 
@@ -81,7 +81,7 @@ class LaneIntersectionNode(LaneNode):
             waypoint = Waypoint(lane, lane_node, Point.from_shapely(point))
             if requires_entry_waypoint:
                 waypoint.be_entry()
-            if has_predecessor and not are_segments_colinear:
+            if has_predecessor and not are_segments_collinear:
                 waypoint.be_arc_end_connection()
             waypoints.append(waypoint)
 

--- a/terminus/models/lane_simple_node.py
+++ b/terminus/models/lane_simple_node.py
@@ -47,7 +47,7 @@ class LaneSimpleNode(LaneNode):
         else:
             previous_vector = self.center - previous_node.center
             following_vector = following_node.center - self.center
-            # If they are colinear
+            # If they are collinear
             if previous_vector.cross_product(following_vector) == Point(0.0, 0.0, 0.0):
                 return [Waypoint(lane, self, self.center)]
             else:

--- a/terminus/tests/line_segment_test.py
+++ b/terminus/tests/line_segment_test.py
@@ -55,7 +55,7 @@ class LineSegmentTest(unittest.TestCase):
 
     def test_includes_point_buffer(self):
         '''The point is slightly outside the line, so by increasing the buffer
-        we use to test colinearity between vectors we make it pass'''
+        we use to test collinearity between vectors we make it pass'''
         segment = LineSegment(Point(0, 0), Point(1, 0))
         self.assertTrue(segment.includes_point(Point(0.5, 0)))
         self.assertFalse(segment.includes_point(Point(0.5, 0.01)))


### PR DESCRIPTION
Fixes #201

This PR adds support for trimming redundant nodes in roads. A node was originally considered redundant in a road if it was not an intersection and connected two collinear segments. However, after some trials with OSM data, we found that we could relax this a little bit and, instead of only removing segments that were strictly collinear (i.e. whose difference in angle was 0), we could work with a given tolerance measured in degrees. A 1° angle with our OSM samples proved to generate road geometries that couldn’t be distinguished by the human eye while removing between 9% and 20% of the nodes in the roads (2° did however show some visible changes on geometry).

Below are some stats on using the old data, 1 and 2 degrees tolerance on MCity:

**Original**
```
====================================
Statistics for city_1
====================================
Roads: 33
Intersections: 46
Lanes: 33
Total lane nodes: 291
Total lane intersections: 100
Average lane nodes: 8.81818181818
Average lane intersections: 3.0303030303
Buildings: 2
Blocks: 0
====================================
```

**1 deg**
```
====================================
Statistics for city_1
====================================
Roads: 33
Intersections: 46
Lanes: 33
Total lane nodes: 266
Total lane intersections: 100
Average lane nodes: 8.06060606061
Average lane intersections: 3.0303030303
Buildings: 2
Blocks: 0
====================================
```

**2 deg**
```
====================================
Statistics for city_1
====================================
Roads: 33
Intersections: 46
Lanes: 33
Total lane nodes: 256
Total lane intersections: 100
Average lane nodes: 7.75757575758
Average lane intersections: 3.0303030303
Buildings: 2
Blocks: 0
```

And the generated monolane files:


![trim_1](https://cloud.githubusercontent.com/assets/4070228/23970547/e457bfdc-09a8-11e7-8bf2-6519437824ee.png)

![trim_2](https://cloud.githubusercontent.com/assets/4070228/23970555/e8ce49dc-09a8-11e7-9cf0-d3caf11ffb1d.png)

OSM sample of OSRF:

**Original**
```
====================================
Statistics for city_1
====================================
Roads: 225
Intersections: 200
Lanes: 225
Total lane nodes: 1000
Total lane intersections: 449
Average lane nodes: 4.44444444444
Average lane intersections: 1.99555555556
Buildings: 1505
Blocks: 0
```

**1 deg**
```
====================================
Statistics for city_1
====================================
Roads: 225
Intersections: 200
Lanes: 225
Total lane nodes: 817
Total lane intersections: 449
Average lane nodes: 3.63111111111
Average lane intersections: 1.99555555556
Buildings: 1505
Blocks: 0
====================================
```

![trim_3](https://cloud.githubusercontent.com/assets/4070228/23970621/2b274644-09a9-11e7-9e32-41800a2576c6.png)
