### PR TITLE
Fix osm builder and connecting waypoints

### DIFF
--- a/terminus/generators/monolane_generator.py
+++ b/terminus/generators/monolane_generator.py
@@ -116,7 +116,7 @@ class MonolaneGenerator(FileGenerator):
 
         primitive = connection.primitive()
 
-        radius = round(primitive.radius(), 7)
+        radius = primitive.radius()
 
         # If the turning radius is less than the driveable_bounds then
         # don't generate the connection

--- a/terminus/geometry/arc.py
+++ b/terminus/geometry/arc.py
@@ -131,23 +131,11 @@ class Arc(object):
         angle = self._angular_offset_for_point(point)
         return abs(math.pi * self._radius * angle / 180.0)
 
-    def point_at_linear_offset(self, reference_point, offset):
+    def points_at_linear_offset(self, reference_point, offset):
         circle1 = Circle(self.center_point(), self.radius())
         circle2 = Circle(reference_point, abs(offset))
         intersections = circle1.intersection(circle2)
-        candidates = filter(lambda point: self.includes_point(point), intersections)
-
-        if not candidates:
-            return None
-        elif len(candidates) == 1:
-            return candidates[0]
-        else:
-            candidates = sorted(candidates,
-                                key=lambda point: self.offset_for_point(point))
-            if offset < 0:
-                return candidates[0]
-            else:
-                return candidates[1]
+        return filter(lambda point: self.includes_point(point), intersections)
 
     def split_into(self, pairs):
         arcs = []

--- a/terminus/geometry/bounding_box.py
+++ b/terminus/geometry/bounding_box.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 from geometry.point import Point
+from geometry.line_segment import LineSegment
 
 
 class BoundingBox(object):
@@ -57,6 +58,26 @@ class BoundingBox(object):
 
     def height(self):
         return self.corner.y - self.origin.y
+
+    def top_left(self):
+        return Point(self.corner.x, self.origin.y)
+
+    def top_right(self):
+        return self.corner.clone()
+
+    def bottom_left(self):
+        return self.origin.clone()
+
+    def bottom_right(self):
+        return Point(self.origin.x, self.corner.y)
+
+    def perimeter(self):
+        return [
+            LineSegment(self.top_left(), self.top_right()),
+            LineSegment(self.top_right(), self.bottom_right()),
+            LineSegment(self.bottom_right(), self.bottom_left()),
+            LineSegment(self.bottom_left(), self.top_left())
+        ]
 
     def _normalize(self):
         new_origin = self.origin.min(self.corner)

--- a/terminus/geometry/line_segment.py
+++ b/terminus/geometry/line_segment.py
@@ -108,6 +108,12 @@ class LineSegment(object):
         else:
             return []
 
+    def _find_bounding_box_intersection(self, bounding_box):
+        intersections = []
+        for segment in bounding_box.perimeter():
+            intersections.extend(self.find_intersection(segment))
+        return intersections
+
     def _find_arc_intersection(self, arc):
         local_segment = self.translate_by(arc.center_point().negated())
         local_segment_vector = local_segment.direction_vector()
@@ -174,6 +180,8 @@ class LineSegment(object):
             return self._find_line_segment_intersection(other)
         elif isinstance(other, geometry.arc.Arc):
             return self._find_arc_intersection(other)
+        elif isinstance(other, geometry.bounding_box.BoundingBox):
+            return self._find_bounding_box_intersection(other)
         else:
             raise ValueError("Intersection between {0} and {1} not supported".format(self, other))
 
@@ -258,6 +266,37 @@ class LineSegment(object):
 
     def is_valid_path_connection(self):
         return self.length() >= 5
+
+    def trim_to_fit(self, bounding_box):
+        if self.is_inside(bounding_box):
+            return [self]
+        if self.is_outside(bounding_box):
+            return []
+
+        intersections = self.find_intersection(bounding_box)
+        if len(intersections) == 1:
+            if bounding_box.includes_point(self.start_point()):
+                return [LineSegment(self.start_point(), intersections[0])]
+            elif bounding_box.includes_point(self.end_point()):
+                return [LineSegment(intersections[0], self.end_point())]
+            else:
+                raise ValueError("Something in the math is wrong")
+        elif len(intersections) == 2:
+            if bounding_box.includes_point(self.start_point()) or \
+               bounding_box.includes_point(self.end_point()):
+                raise ValueError("Something in the math is wrong")
+            return [LineSegment(intersections[0], intersections[1])]
+        else:
+            raise ValueError("Something in the math is wrong - Multiple intersections")
+
+    def is_inside(self, bounding_box):
+        return bounding_box.includes_point(self.start_point()) and \
+            bounding_box.includes_point(self.end_point())
+
+    def is_outside(self, bounding_box):
+        return not bounding_box.includes_point(self.start_point()) and \
+            not bounding_box.includes_point(self.end_point()) and \
+            not self.find_intersection(bounding_box)
 
     def __eq__(self, other):
         return self.a == other.a and self.b == other.b

--- a/terminus/geometry/line_segment.py
+++ b/terminus/geometry/line_segment.py
@@ -219,19 +219,9 @@ class LineSegment(object):
         return Point(self.a.x + dx / linelen * offset,
                      self.a.y + dy / linelen * offset)
 
-    def point_at_linear_offset(self, reference_point, offset):
+    def points_at_linear_offset(self, reference_point, offset):
         circle = geometry.circle.Circle(reference_point, abs(offset))
-        intersections = self._find_circle_intersection(circle)
-        if not intersections:
-            return None
-        elif len(intersections) == 1:
-            return intersections[0]
-        else:
-            local_offset = self.offset_for_point(reference_point)
-            local_nearest_point = self.point_at_offset(local_offset + offset)
-            intersections = sorted(intersections,
-                                   key=lambda point: point.squared_distance_to(local_nearest_point))
-            return intersections[0]
+        return self._find_circle_intersection(circle)
 
     def offset_for_point(self, point):
         if not self.includes_point(point):

--- a/terminus/geometry/path.py
+++ b/terminus/geometry/path.py
@@ -1,0 +1,106 @@
+"""
+Copyright (C) 2017 Open Source Robotics Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from geometry.line_segment import LineSegment
+
+
+class Path(object):
+    """A path is a collection of geometry elements where, for two consecutive
+    element E_n and E_n+1 it holds that E_n last point == E_n+1 start point
+    """
+
+    def __init__(self, elements=None):
+        self._elements = []
+        if elements:
+            self._elements.extend(elements)
+
+    @classmethod
+    def polyline_from_points(cls, points):
+        if len(points) < 2:
+            raise ValueError("{0} points given. At least two points are needed".format(points))
+        pairs = zip(points, points[1:])
+        segments = map(lambda (p1, p2): LineSegment(p1, p2), pairs)
+        return cls(segments)
+
+    def not_empty(self):
+        return self.elements_count() > 0
+
+    def is_empty(self):
+        return self.elements_count() == 0
+
+    def elements_count(self):
+        return len(self._elements)
+
+    def elements(self):
+        return self._elements
+
+    def element_at(self, index):
+        return self._elements[index]
+
+    def first_element(self):
+        return self.element_at(0)
+
+    def last_element(self):
+        return self.element_at(-1)
+
+    def start_point(self):
+        return self.element_at(0).start_point()
+
+    def end_point(self):
+        return self.element_at(-1).end_point()
+
+    def length(self):
+        return sum(map(lambda element: element.length(), self.elements()))
+
+    def add_element(self, element):
+        if self.not_empty() and \
+           not self.end_point().almost_equal_to(element.start_point(), 7):
+            raise ValueError("{0} start point doesn't match path last point {1}".format(element, self.end_point()))
+        self._elements.append(element)
+
+    def reversed(self):
+        copied_elements = list(self._elements).reverse()
+        return Path(copied_elements)
+
+    def vertices(self):
+        points = map(lambda element: element.start_point(), self._elements)
+        points.append(self.end_point())
+        return points
+
+    def trim_to_fit(self, bounding_box):
+        paths = [Path()]
+        for element in self:
+            current_path = paths[-1]
+            if element.is_inside(bounding_box):
+                current_path.add_element(element)
+            elif element.is_outside(bounding_box):
+                pass
+            else:
+                split = element.trim_to_fit(bounding_box)
+                for sub_element in split:
+                    if current_path.not_empty() and \
+                       not current_path.end_point().almost_equal_to(sub_element.start_point(), 7):
+                        current_path = Path()
+                        paths.append(current_path)
+                    current_path.add_element(sub_element)
+        return paths
+
+    def __iter__(self):
+        return iter(self._elements)
+
+    def __repr__(self):
+        parts = ', '.join(map(str, self.elements()))
+        return "Path({0})".format(parts)

--- a/terminus/models/path_geometry.py
+++ b/terminus/models/path_geometry.py
@@ -122,24 +122,18 @@ class PathGeometry(object):
             self._waypoints.append(waypoint)
         return self._waypoints
 
-    def point_at_linear_offset(self, reference_point, offset):
+    def point_at_linear_offset(self, reference_point, center, distance):
         matches = []
         for element in self.elements():
-            point = element.point_at_linear_offset(reference_point, offset)
-            if point:
-                rounded_point = point.rounded_to(10)
-                if rounded_point not in matches:
-                    matches.append(rounded_point)
-        if len(matches) == 1:
-            return matches[0]
-        # TODO: Replace this with an assertion
-        if len(matches) > 2:
-            raise ValueError("Too many matches")
+            matches.extend(element.points_at_linear_offset(center, distance))
+
+        if not matches:
+            raise ValueError("Couldn't find any point at the requested linear offset")
         else:
-            if offset < 0:
-                return matches[0]
-            else:
-                return matches[1]
+            reference_offset = self.offset_for_point(reference_point)
+            matches = sorted(matches,
+                             key=lambda point: abs(reference_offset - self.offset_for_point(point)))
+            return matches[0]
 
     def heading_at_point(self, point):
         # TODO: Improve performance

--- a/terminus/models/path_geometry_builder.py
+++ b/terminus/models/path_geometry_builder.py
@@ -109,11 +109,11 @@ class PathGeometryBuilder(object):
             raise ValueError("Intersection list is empty, can't pick a value")
 
         if len(intersections) > 1:
-            logger.warn("Multiple intersections found between geometries. Picking the closest one.")
-            logger.warn("ROAD NODE: {0}".format(road_node))
-            logger.warn("SOURCE: {0}".format(source_geometry))
-            logger.warn("TARGET: {0}".format(target_geometry))
-            logger.warn("INTERSECTIONS: {0}".format(intersections))
+            logger.debug("Multiple intersections found between geometries. Picking the closest one.")
+            logger.debug("ROAD NODE: {0}".format(road_node))
+            logger.debug("SOURCE: {0}".format(source_geometry))
+            logger.debug("TARGET: {0}".format(target_geometry))
+            logger.debug("INTERSECTIONS: {0}".format(intersections))
             intersections = sorted(intersections,
                                    key=lambda point: point.squared_distance_to(intersection_control_point))
 

--- a/terminus/models/road.py
+++ b/terminus/models/road.py
@@ -75,6 +75,10 @@ class Road(CityModel):
         self._add_node(node)
         self._point_to_node[point] = node
 
+    def add_control_points(self, points):
+        for point in points:
+            self.add_control_point(point)
+
     def control_points_count(self):
         return len(self._nodes)
 

--- a/terminus/models/waypoint.py
+++ b/terminus/models/waypoint.py
@@ -16,8 +16,6 @@ limitations under the License.
 
 from geometry.point import Point
 
-from waypoint_connection import WaypointConnection
-
 
 class Waypoint(object):
 
@@ -29,6 +27,9 @@ class Waypoint(object):
         self._road_node = road_node
         self._in_connections = []
         self._out_connections = []
+
+    def is_proxy(self):
+        return False
 
     def road_node(self):
         return self._road_node

--- a/terminus/models/waypoint_connection.py
+++ b/terminus/models/waypoint_connection.py
@@ -23,9 +23,13 @@ class WaypointConnection(object):
         self._primitive = primitive
 
     def start_waypoint(self):
+        if self._start_waypoint.is_proxy():
+            self._start_waypoint = self._start_waypoint.resolve()
         return self._start_waypoint
 
     def end_waypoint(self):
+        if self._end_waypoint.is_proxy():
+            self._end_waypoint = self._end_waypoint.resolve()
         return self._end_waypoint
 
     def primitive(self):

--- a/terminus/models/waypoint_geometry.py
+++ b/terminus/models/waypoint_geometry.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 from geometry.point import Point
 from waypoint import Waypoint
+from waypoint_proxy import WaypointProxy
 from waypoint_connection import WaypointConnection
 
 import logging
@@ -47,7 +48,6 @@ class WaypointGeometry(object):
     def _build_prmitives(self):
         self._waypoints = self._build_waypoints()
         self._waypoints = self._remove_redundant_waypoints()
-        self._split_geometry = self._geometry.split_in(self._waypoints)
         self._connections = self._build_connections()
 
     def _build_waypoints(self):
@@ -96,14 +96,18 @@ class WaypointGeometry(object):
         out_connection = self._find_connection(4, road_node, intersection, target_lane, target_geometry, source_lane, source_geometry)
 
         if out_connection:
-            entry_waypoint, exit_waypoint, connection = out_connection
+            entry_waypoint, exit_waypoint, primitive = out_connection
+            entry_proxy = WaypointProxy(target_lane, self._builder.__class__, entry_waypoint.center(), road_node)
+            connection = WaypointConnection(exit_waypoint, entry_proxy, primitive)
             exit_waypoint.add_out_connection(connection)
             waypoints.append(exit_waypoint)
 
         in_connection = self._find_connection(4, road_node, intersection, source_lane, source_geometry, target_lane, target_geometry)
 
         if in_connection:
-            entry_waypoint, exit_waypoint, connection = in_connection
+            entry_waypoint, exit_waypoint, primitive = in_connection
+            exit_proxy = WaypointProxy(source_lane, self._builder.__class__, exit_waypoint.center(), road_node)
+            connection = WaypointConnection(exit_proxy, entry_waypoint, primitive)
             entry_waypoint.add_in_connection(connection)
             waypoints.append(entry_waypoint)
 
@@ -123,20 +127,21 @@ class WaypointGeometry(object):
             raise ValueError("Intersection list is empty, can't pick a value")
 
         if len(intersections) > 1:
-            logger.warn("Multiple intersections found between geometries. Picking the closest one.")
-            logger.warn("ROAD NODE: {0}".format(road_node))
-            logger.warn("SOURCE: {0}".format(source_geometry))
-            logger.warn("TARGET: {0}".format(target_geometry))
-            logger.warn("INTERSECTIONS: {0}".format(intersections))
+            logger.debug("Multiple intersections found between geometries. Picking the closest one.")
+            logger.debug("ROAD NODE: {0}".format(road_node))
+            logger.debug("SOURCE: {0}".format(source_geometry))
+            logger.debug("TARGET: {0}".format(target_geometry))
+            logger.debug("INTERSECTIONS: {0}".format(intersections))
             intersections = sorted(intersections,
                                    key=lambda point: point.squared_distance_to(intersection_control_point))
 
         return intersections[0]
 
     def _build_connections(self):
+        split_geometry = self._geometry.split_in(self._waypoints)
         waypoint_index = 0
         connections = []
-        for element in self._split_geometry.elements():
+        for element in split_geometry.elements():
             start_waypoint = self._waypoints[waypoint_index]
             waypoint_index += 1
             end_waypoint = self._waypoints[waypoint_index]
@@ -204,7 +209,7 @@ class WaypointGeometry(object):
                 if connection is None:
                     connection_offset += 0.5
                 else:
-                    return (entry_waypoint, exit_waypoint, connection)
+                    return connection
             else:
                 if failed_attempts:
                     logger.error("Failed to connect {0} and {1} at {2}".format(source_geometry, target_geometry, intersection))
@@ -217,6 +222,6 @@ class WaypointGeometry(object):
                 message_template = "Bad connection between {0} and {1}\nUsing {2}\nExpecting {3} but {4} given"
                 message = message_template.format(exit_waypoint, entry_waypoint, primitive, entry_waypoint.center(), primitive.end_point())
                 raise RuntimeError(message)
-            return WaypointConnection(exit_waypoint, entry_waypoint, primitive)
+            return (entry_waypoint, exit_waypoint, primitive)
         else:
             return None

--- a/terminus/models/waypoint_proxy.py
+++ b/terminus/models/waypoint_proxy.py
@@ -1,0 +1,58 @@
+"""
+Copyright (C) 2017 Open Source Robotics Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from geometry.point import Point
+
+
+class WaypointProxy(object):
+
+    def __init__(self, lane, geometry_builder, center, road_node):
+        self._lane = lane
+        self._geometry_builder = geometry_builder
+        self._center = center
+        self._road_node = road_node
+
+    def is_proxy(self):
+        return True
+
+    def center(self):
+        return self._center
+
+    def road_node(self):
+        return self._road_node
+
+    def resolve(self):
+        waypoints = self._lane.waypoints_using(self._geometry_builder)
+        for waypoint in waypoints:
+            if waypoint.center().rounded_to(7) == self.center().rounded_to(7) and \
+               waypoint.road_node() == self.road_node():
+                return waypoint
+        raise RuntimeError("Could not resolve waypoint")
+
+    def __eq__(self, other):
+        return (self.__class__ == other.__class__) and \
+               (self._center.rounded_to(7) == other._center.rounded_to(7)) and \
+               (self._lane == other._lane) and \
+               (self._geometry_builder == other._geometry_builder)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return hash((self._lane, self._geometry_builder, self._center.rounded_to(7)))
+
+    def __repr__(self):
+        return "WaypointProxy at {0}".format(self.center())

--- a/terminus/tests/monolane_generator_test.py
+++ b/terminus/tests/monolane_generator_test.py
@@ -188,11 +188,11 @@ class MonolaneGeneratorTest(unittest.TestCase):
             s1_1_1-s1_1_2: {start: points.s1_1_1, length: 96.0, explicit_end: points.s1_1_2}
             s1_1_2-s2_1_2:
               start: points.s1_1_2
-              arc: [9.6568542, -45.0]
+              arc: [9.656854249492381, -45.0]
               explicit_end: points.s2_1_2
             s1_1_2-s3_1_2:
               start: points.s1_1_2
-              arc: [9.6568542, 45.0]
+              arc: [9.656854249492381, 45.0]
               explicit_end: points.s3_1_2
             s2_1_2-s2_1_3: {start: points.s2_1_2, length: 137.4213562373095, explicit_end: points.s2_1_3}
             s3_1_2-s3_1_3: {start: points.s3_1_2, length: 137.4213562373095, explicit_end: points.s3_1_3}
@@ -235,12 +235,12 @@ class MonolaneGeneratorTest(unittest.TestCase):
             s2_1_1-s2_1_2: {start: points.s2_1_1, length: 137.4213562373095, explicit_end: points.s2_1_2}
             s2_1_2-s1_1_2:
               start: points.s2_1_2
-              arc: [9.6568542, 45.0]
+              arc: [9.656854249492373, 45.0]
               explicit_end: points.s1_1_2
             s3_1_1-s3_1_2: {start: points.s3_1_1, length: 137.4213562373095, explicit_end: points.s3_1_2}
             s3_1_2-s1_1_2:
               start: points.s3_1_2
-              arc: [9.6568542, -45.0]
+              arc: [9.656854249492373, -45.0]
               explicit_end: points.s1_1_2
           groups: {}""")
 
@@ -343,17 +343,17 @@ class MonolaneGeneratorTest(unittest.TestCase):
             s1_1_1-s1_1_2: {start: points.s1_1_1, length: 45.0, explicit_end: points.s1_1_2}
             s1_1_2-s2_1_3:
               start: points.s1_1_2
-              arc: [5.0, 90.0]
+              arc: [5.0000000000000036, 90.0]
               explicit_end: points.s2_1_3
             s1_1_2-s1_1_3:
               start: points.s1_1_2
-              arc: [25.962912, 21.8014095]
+              arc: [25.962912017836256, 21.8014095]
               explicit_end: points.s1_1_3
             s1_1_3-s1_1_4: {start: points.s1_1_3, length: 48.851648071345046, explicit_end: points.s1_1_4}
             s2_1_1-s2_1_2: {start: points.s2_1_1, length: 45.0, explicit_end: points.s2_1_2}
             s2_1_2-s1_1_3:
               start: points.s2_1_2
-              arc: [7.3851648, -68.1985905]
+              arc: [7.385164807134516, -68.1985905]
               explicit_end: points.s1_1_3
             s2_1_2-s2_1_3: {start: points.s2_1_2, length: 10.000000000000007, explicit_end: points.s2_1_3}
             s2_1_3-s2_1_4: {start: points.s2_1_3, length: 44.99999999999999, explicit_end: points.s2_1_4}
@@ -392,21 +392,21 @@ class MonolaneGeneratorTest(unittest.TestCase):
             s1_1_1-s1_1_2: {start: points.s1_1_1, length: 45.0, explicit_end: points.s1_1_2}
             s1_1_2-s2_1_3:
               start: points.s1_1_2
-              arc: [6.0990195, 78.6900675]
+              arc: [6.0990195135927845, 78.6900675]
               explicit_end: points.s2_1_3
             s1_1_2-s1_1_3:
               start: points.s1_1_2
-              arc: [25.962912, 21.8014095]
+              arc: [25.962912017836256, 21.8014095]
               explicit_end: points.s1_1_3
             s1_1_3-s1_1_4: {start: points.s1_1_3, length: 48.851648071345046, explicit_end: points.s1_1_4}
             s2_1_1-s2_1_2: {start: points.s2_1_1, length: 45.0, explicit_end: points.s2_1_2}
             s2_1_2-s1_1_3:
               start: points.s2_1_2
-              arc: [7.3851648, -68.1985905]
+              arc: [7.385164807134505, -68.1985905]
               explicit_end: points.s1_1_3
             s2_1_2-s2_1_3:
               start: points.s2_1_2
-              arc: [50.4950976, -11.3099325]
+              arc: [50.495097567964, -11.3099325]
               explicit_end: points.s2_1_3
             s2_1_3-s2_1_4: {start: points.s2_1_3, length: 45.99019513592784, explicit_end: points.s2_1_4}
           groups: {}""")
@@ -441,13 +441,13 @@ class MonolaneGeneratorTest(unittest.TestCase):
             s1_1_1-s1_1_2: {start: points.s1_1_1, length: 45.0, explicit_end: points.s1_1_2}
             s1_1_2-s1_1_3:
               start: points.s1_1_2
-              arc: [18.0515865, 30.9637565]
+              arc: [18.051586491408834, 30.9637565]
               explicit_end: points.s1_1_3
             s1_1_3-s1_1_4: {start: points.s1_1_3, length: 53.309518948453004, explicit_end: points.s1_1_4}
             s2_1_1-s2_1_2: {start: points.s2_1_1, length: 45.00000000000004, explicit_end: points.s2_1_2}
             s2_1_2-s1_1_3:
               start: points.s2_1_2
-              arc: [8.8309519, -59.0362435]
+              arc: [8.83095189484526, -59.0362435]
               explicit_end: points.s1_1_3
           groups: {}""")
 
@@ -472,7 +472,7 @@ class MonolaneGeneratorTest(unittest.TestCase):
             s1_1_1-s1_1_2: {start: points.s1_1_1, length: 95.0, explicit_end: points.s1_1_2}
             s1_1_2-s1_1_3:
               start: points.s1_1_2
-              arc: [34.0671775, 16.6992442]
+              arc: [34.06717751485093, 16.6992442]
               explicit_end: points.s1_1_3
             s1_1_3-s1_1_4: {start: points.s1_1_3, length: 99.4030650891055, explicit_end: points.s1_1_4}
           groups: {}""")
@@ -504,12 +504,12 @@ class MonolaneGeneratorTest(unittest.TestCase):
             s1_1_1-s1_1_2: {start: points.s1_1_1, length: 5.0, explicit_end: points.s1_1_2}
             s1_1_2-s1_1_3:
               start: points.s1_1_2
-              arc: [50.4950976, 11.3099325]
+              arc: [50.49509756796387, 11.3099325]
               explicit_end: points.s1_1_3
             s1_1_3-s1_1_4: {start: points.s1_1_3, length: 0.19803902718558075, explicit_end: points.s1_1_4}
             s1_1_4-s1_1_5:
               start: points.s1_1_4
-              arc: [37.3362571, 15.2551187]
+              arc: [37.336257084985604, 15.2551187]
               explicit_end: points.s1_1_5
             s1_1_5-s1_1_6: {start: points.s1_1_5, length: 6.180339887498981, explicit_end: points.s1_1_6}
           groups: {}""")
@@ -538,11 +538,11 @@ class MonolaneGeneratorTest(unittest.TestCase):
             s1_1_1-s1_1_2: {start: points.s1_1_1, length: 7.76393202250021, explicit_end: points.s1_1_2}
             s1_1_2-s1_1_3:
               start: points.s1_1_2
-              arc: [9.472136, 26.5650512]
+              arc: [9.47213595499958, 26.5650512]
               explicit_end: points.s1_1_3
             s1_1_3-s1_1_4:
               start: points.s1_1_3
-              arc: [27.758298, -9.2110265]
+              arc: [27.75829803978227, -9.2110265]
               explicit_end: points.s1_1_4
             s1_1_4-s1_1_5: {start: points.s1_1_4, length: 14.526986636740412, explicit_end: points.s1_1_5}
           groups: {}""")

--- a/terminus/tests/monolane_generator_test.py
+++ b/terminus/tests/monolane_generator_test.py
@@ -194,8 +194,8 @@ class MonolaneGeneratorTest(unittest.TestCase):
               start: points.s1_1_2
               arc: [9.6568542, 45.0]
               explicit_end: points.s3_1_2
-            s2_1_2-s2_1_3: {start: points.s2_1_2, length: 137.42135623737482, explicit_end: points.s2_1_3}
-            s3_1_2-s3_1_3: {start: points.s3_1_2, length: 137.42135623737482, explicit_end: points.s3_1_3}
+            s2_1_2-s2_1_3: {start: points.s2_1_2, length: 137.4213562373095, explicit_end: points.s2_1_3}
+            s3_1_2-s3_1_3: {start: points.s3_1_2, length: 137.4213562373095, explicit_end: points.s3_1_3}
           groups: {}""")
 
     def test_Y_intersection_many_to_one(self):
@@ -232,12 +232,12 @@ class MonolaneGeneratorTest(unittest.TestCase):
               zpoint: [0.0, 0, 0, 0]
           connections:
             s1_1_2-s1_1_3: {start: points.s1_1_2, length: 96.0, explicit_end: points.s1_1_3}
-            s2_1_1-s2_1_2: {start: points.s2_1_1, length: 137.42135623737482, explicit_end: points.s2_1_2}
+            s2_1_1-s2_1_2: {start: points.s2_1_1, length: 137.4213562373095, explicit_end: points.s2_1_2}
             s2_1_2-s1_1_2:
               start: points.s2_1_2
               arc: [9.6568542, 45.0]
               explicit_end: points.s1_1_2
-            s3_1_1-s3_1_2: {start: points.s3_1_1, length: 137.42135623737482, explicit_end: points.s3_1_2}
+            s3_1_1-s3_1_2: {start: points.s3_1_1, length: 137.4213562373095, explicit_end: points.s3_1_2}
             s3_1_2-s1_1_2:
               start: points.s3_1_2
               arc: [9.6568542, -45.0]
@@ -355,8 +355,8 @@ class MonolaneGeneratorTest(unittest.TestCase):
               start: points.s2_1_2
               arc: [7.3851648, -68.1985905]
               explicit_end: points.s1_1_3
-            s2_1_2-s2_1_3: {start: points.s2_1_2, length: 10.0, explicit_end: points.s2_1_3}
-            s2_1_3-s2_1_4: {start: points.s2_1_3, length: 45.0, explicit_end: points.s2_1_4}
+            s2_1_2-s2_1_3: {start: points.s2_1_2, length: 10.000000000000007, explicit_end: points.s2_1_3}
+            s2_1_3-s2_1_4: {start: points.s2_1_3, length: 44.99999999999999, explicit_end: points.s2_1_4}
           groups: {}""")
 
     def test_broken_intersection_on_two_lanes_city(self):
@@ -444,7 +444,7 @@ class MonolaneGeneratorTest(unittest.TestCase):
               arc: [18.0515865, 30.9637565]
               explicit_end: points.s1_1_3
             s1_1_3-s1_1_4: {start: points.s1_1_3, length: 53.309518948453004, explicit_end: points.s1_1_4}
-            s2_1_1-s2_1_2: {start: points.s2_1_1, length: 45.0, explicit_end: points.s2_1_2}
+            s2_1_1-s2_1_2: {start: points.s2_1_1, length: 45.00000000000004, explicit_end: points.s2_1_2}
             s2_1_2-s1_1_3:
               start: points.s2_1_2
               arc: [8.8309519, -59.0362435]


### PR DESCRIPTION
- Fix OSM builder not clipping roads correctly
- Avoid creating multiple similar waypoints in connections; use proxies to lazily get them once they are generated in the target lane