### PR TITLE
Add licence to files generated from OSM data

### DIFF
--- a/terminus/builders/abstract_city_builder.py
+++ b/terminus/builders/abstract_city_builder.py
@@ -21,4 +21,12 @@ class AbstractCityBuilder(object):
         return self.__class__.__name__
 
     def get_city(self):
+        city = self._buid_city()
+        city.put_metadata('builder', self)
+        return city
+
+    def required_licence(self):
+        return None
+
+    def _buid_city(self):
         raise NotImplementedError()

--- a/terminus/builders/osm_city_builder.py
+++ b/terminus/builders/osm_city_builder.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import textwrap
 
 from geometry.point import Point
 from geometry.latlon import LatLon
@@ -51,7 +52,16 @@ class OsmCityBuilder(AbstractCityBuilder):
                            'tertiary', 'unclassified', 'residential',
                            'living_street']
 
-    def get_city(self):
+    def required_licence(self):
+        return textwrap.dedent("""
+        Map data from (c) OpenStreetMap contributors.
+        This {filename} is made available under the
+        Open Database License: http://opendatacommons.org/licenses/odbl/1.0/.
+        Any rights in individual contents of the database are licensed under the
+        Database Contents License: http://opendatacommons.org/licenses/dbcl/1.0/
+        """)[1:]
+
+    def _buid_city(self):
         city = City()
 
         # Get origin of the map (we use the center)

--- a/terminus/builders/procedural_city_builder.py
+++ b/terminus/builders/procedural_city_builder.py
@@ -50,7 +50,7 @@ class ProceduralCityBuilder(AbstractCityBuilder):
         self.ratio = 100  # ratio between pcg and gazebo (1unit = 100m)
         self.pcg_runner.set_size(size / self.ratio)
 
-    def get_city(self):
+    def _buid_city(self):
         city = City()
 
         # If no verticesFilename or polygonsFilename is specified,

--- a/terminus/builders/simple_city_builder.py
+++ b/terminus/builders/simple_city_builder.py
@@ -29,7 +29,7 @@ from builders.abstract_city_builder import AbstractCityBuilder
 
 class SimpleCityBuilder(AbstractCityBuilder):
 
-    def get_city(self):
+    def _buid_city(self):
         # Must be odd
         size = 5
         city = City()

--- a/terminus/generators/monolane_generator.py
+++ b/terminus/generators/monolane_generator.py
@@ -291,3 +291,10 @@ class MonolaneGenerator(FileGenerator):
 
         OrderedDumper.add_representer(OrderedDict, _dict_representer)
         return header + yaml.dump(self.monolane, None, OrderedDumper)
+
+    def _prepare_licence(self, contents):
+        contents = self.comment(contents + "\n")
+        return contents + "\n"
+
+    def comment(self, text):
+        return '# ' + ("\n# ".join(text.splitlines()))

--- a/terminus/generators/rndf_generator.py
+++ b/terminus/generators/rndf_generator.py
@@ -128,3 +128,11 @@ class RNDFGenerator(FileGenerator):
 
     def trunk_template(self):
         return self.road_template()
+
+    def _prepare_licence(self, contents):
+        contents = self.comment(contents)
+        return contents + "\n\n"
+
+    def comment(self, text):
+        lines = map(lambda str: "/* {0} */".format(str), text.splitlines())
+        return "\n".join(lines)

--- a/terminus/models/city.py
+++ b/terminus/models/city.py
@@ -33,6 +33,13 @@ class City(CityModel):
         self.blocks = []
         self.buildings = []
         self.intersections = {}
+        self._metadata = {}
+
+    def put_metadata(self, key, value):
+        self._metadata[key] = value
+
+    def get_metadata(self, key):
+        return self._metadata.get(key, None)
 
     def set_ground_plane(self, ground_plane):
         self.ground_plane = ground_plane


### PR DESCRIPTION
Fixes #242

Sample RNDF file header:

```
/* Map data from (c) OpenStreetMap contributors. */
/* This city.rndf is made available under the */
/* Open Database License: http://opendatacommons.org/licenses/odbl/1.0/. */
/* Any rights in individual contents of the database are licensed under the */
/* Database Contents License: http://opendatacommons.org/licenses/dbcl/1.0/ */
```

Sample monolane header:

```
# Map data from (c) OpenStreetMap contributors.
# This city_monolane.yaml is made available under the
# Open Database License: http://opendatacommons.org/licenses/odbl/1.0/.
# Any rights in individual contents of the database are licensed under the
# Database Contents License: http://opendatacommons.org/licenses/dbcl/1.0/
# 
# -*- yaml -*-
```
