### PR TITLE
Restore multilane support

### DIFF
--- a/terminus/builders/osm_city_builder.py
+++ b/terminus/builders/osm_city_builder.py
@@ -141,12 +141,11 @@ class OsmCityBuilder(AbstractCityBuilder):
 
         return geometry.trim_to_fit(self.bounding_box)
 
-    def _create_road(self, city, osm_id, geometry, is_one_way, is_reversed):
-        if is_one_way:
-            road = Street(name='OSM_' + osm_id)
+    def _create_road(self, city, osm_id, geometry, is_one_way, is_reversed, is_trunk):
+        if is_trunk:
+            road = Trunk(name='OSM_' + osm_id)
         else:
             road = Street(name='OSM_' + osm_id)
-            # tmp_road = Trunk(name='OSM_' + str(osm_id))
 
         if is_reversed:
             geometry = geometry.reversed()
@@ -177,16 +176,19 @@ class OsmCityBuilder(AbstractCityBuilder):
                 # Check if the points were given in reversed order
                 is_reversed = is_one_way and (value['tags']['oneway'] in ['-1', 'reverse'])
 
+                # This should be improved in the future
+                is_trunk = tags['highway'] in ['trunk', 'primary', 'secondary']
+
                 # The road went outside the bounding box and back in. For that
                 # case we will generate a new road for each piece.
                 if len(geometry) > 1:
                     index = "A"
                     for road_geometry in geometry:
-                        self._create_road(city, str(osmid) + "_" + index, road_geometry, is_one_way, is_reversed)
+                        self._create_road(city, str(osmid) + "_" + index, road_geometry, is_one_way, is_reversed, is_trunk)
                         index = chr(ord(index) + 1)
                 else:
                     road_geometry = geometry[0]
-                    self._create_road(city, str(osmid), road_geometry, is_one_way, is_reversed)
+                    self._create_road(city, str(osmid), road_geometry, is_one_way, is_reversed, is_trunk)
 
     def _create_intersections(self, city):
         for node_id, nodes in self.nodes.iteritems():

--- a/terminus/builders/procedural_city/vertex_graph_to_roads_converter.py
+++ b/terminus/builders/procedural_city/vertex_graph_to_roads_converter.py
@@ -41,11 +41,10 @@ class VertexGraphToRoadsConverter(object):
             while node.get_neighbours_to_traverse():
                 # Revert this commented code once we support trunks in monolane
                 # generator
-                # if node.is_minor_road:
-                #     road = Street()
-                # else:
-                #     road = Trunk()
-                road = Street()
+                if node.is_minor_road:
+                    road = Street()
+                else:
+                    road = Trunk()
                 if node.neighbours_count() > 1:
                     self.city.add_intersection_at(node.location)
 

--- a/terminus/builders/simple_city_builder.py
+++ b/terminus/builders/simple_city_builder.py
@@ -103,22 +103,22 @@ class SimpleCityBuilder(AbstractCityBuilder):
         city.add_road(road)
 
     def _create_surrounding_ring_road(self, city, size):
-        ring_road_1 = Street(name='RingRoad1')
+        ring_road_1 = Trunk(name='RingRoad1')
         for x in range(size):
             ring_road_1.add_control_point(self.intersections[x][0])
         city.add_road(ring_road_1)
 
-        ring_road_2 = Street(name='RingRoad2')
+        ring_road_2 = Trunk(name='RingRoad2')
         for y in range(size):
             ring_road_2.add_control_point(self.intersections[size - 1][y])
         city.add_road(ring_road_2)
 
-        ring_road_3 = Street(name='RingRoad3')
+        ring_road_3 = Trunk(name='RingRoad3')
         for x in range(size):
             ring_road_3.add_control_point(self.intersections[size - x - 1][size - 1])
         city.add_road(ring_road_3)
 
-        ring_road_4 = Street(name='RingRoad4')
+        ring_road_4 = Trunk(name='RingRoad4')
         for y in range(size):
             ring_road_4.add_control_point(self.intersections[0][size - y - 1])
         city.add_road(ring_road_4)

--- a/terminus/generators/monolane_generator.py
+++ b/terminus/generators/monolane_generator.py
@@ -47,7 +47,7 @@ class MonolaneGenerator(FileGenerator):
                 ('id', city.name),
                 ('lane_bounds', [-2, 2]),
                 ('driveable_bounds', [-4, 4]),
-                ('position_precision', 0.0005),
+                ('position_precision', 0.01),
                 ('orientation_precision', 0.5),
                 ('points', OrderedDict()),
                 ('connections', OrderedDict()),

--- a/terminus/models/junction_builder.py
+++ b/terminus/models/junction_builder.py
@@ -28,31 +28,32 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-class IntersectionNotFound(Exception):
-    pass
-
-
 class JunctionNotSatisfied(Exception):
     pass
 
 
 class JunctionBuilder(object):
 
-    def __init__(self, road_node, geometry_class):
+    def __init__(self, road_node, mapped_intersection_center, geometry_class):
         self._road_node = road_node
+        self._mapped_intersection_center = mapped_intersection_center
         self._geometry_class = geometry_class
 
     def lanes(self):
         return self._road_node.involved_lanes()
 
+    def mapped_intersection_center(self):
+        return self._mapped_intersection_center
+
     def intersection_center(self):
         return self._road_node.center
 
     def add_connections_to_lanes(self):
+        lane_pairs = self._create_lane_pairs()
         try:
-            connections = self._fulfill_intersection_with_single_length()
+            connections = self._fulfill_intersection_with_single_length(lane_pairs)
         except JunctionNotSatisfied:
-            connections = self._fulfill_intersection_with_adaptive_approach()
+            connections = self._fulfill_intersection_with_adaptive_approach(lane_pairs)
 
         waypoints_by_lane = OrderedDict()
 
@@ -82,118 +83,42 @@ class JunctionBuilder(object):
             geometry = lane._lane_geometry(self._geometry_class)
             geometry.resolve_intersection(self._road_node, set(waypoints.values()))
 
-    def _fulfill_intersection_with_adaptive_approach(self):
-        up = [x / 2.0 for x in range(10, 31)]  # [5.0, 5.5, 6.0, ...]
-        down = [x / 2.0 for x in reversed(range(1, 10))]  # [4.5, 4.0, ...]
-        radius_candidates = up + down
-        intersections = OrderedDict()
-
-        for radius in radius_candidates:
-            try:
-                intersections = self._create_lane_intersections_mapping(radius)
-            except IntersectionNotFound:
-                pass
-        if not intersections:
-            raise JunctionNotSatisfied()
-
-        waypoints = self._get_waypoints_for_intersections(intersections)
-        exit_waypoints, entry_waypoints = self._split_exit_entry_waypoints(waypoints)
-
+    def _create_lane_pairs(self):
         lane_pairs = OrderedDict()
+        node = self._road_node
+        entry_lanes = []
+        exit_lanes = []
+        for lane in self.lanes():
+            if lane.starts_on(node) and not lane.ends_on(node):
+                entry_lanes.append(lane)
+            elif lane.ends_on(node) and not lane.starts_on(node):
+                exit_lanes.append(lane)
+            else:
+                entry_lanes.append(lane)
+                exit_lanes.append(lane)
 
-        for exit_waypoint in exit_waypoints:
-            for entry_waypoint in entry_waypoints:
-                if exit_waypoint.lane() is not entry_waypoint.lane():
-                    if not exit_waypoint.lane() in lane_pairs:
-                        lane_pairs[exit_waypoint.lane()] = OrderedDict()
-                    lane_pairs[exit_waypoint.lane()][entry_waypoint.lane()] = None
+        for exit_lane in exit_lanes:
+            for entry_lane in entry_lanes:
+                if exit_lane.road() is not entry_lane.road():
+                    lane_pairs[(exit_lane, entry_lane)] = None
+        return lane_pairs
 
-        for radius in radius_candidates:
-            self._fill_missing_connections(radius, lane_pairs, True)
-
-        for radius in radius_candidates:
-            self._fill_missing_connections(radius, lane_pairs, False)
-
-        connections = []
-        for exit_lane, record in lane_pairs.iteritems():
-            for entry_lane, connection in record.iteritems():
-                if not connection:
-                    logger.warn("Connection not fulfilled {0} {1}".format(exit_lane, entry_lane))
-                else:
-                    connections.append(connection)
-
-        return connections
-
-    def _fill_missing_connections(self, radius, lane_pairs, strict):
-        intersections = self._create_lane_intersections_mapping(radius, False)
-
-        waypoints = self._get_waypoints_for_intersections(intersections)
-        exit_waypoints, entry_waypoints = self._split_exit_entry_waypoints(waypoints)
-
-        for index, exit_waypoint in enumerate(exit_waypoints):
-            for exit_lane, record in lane_pairs.iteritems():
-                for entry_lane, connection in record.iteritems():
-                    if connection is not None:
-                        if connection.start_waypoint() == exit_waypoint:
-                            exit_waypoints[index] = connection.start_waypoint()
-
-        for index, entry_waypoint in enumerate(entry_waypoints):
-            for exit_lane, record in lane_pairs.iteritems():
-                for entry_lane, connection in record.iteritems():
-                    if connection is not None:
-                        if connection.end_waypoint() == entry_waypoint:
-                            entry_waypoints[index] = connection.end_waypoint()
-
-        for exit_waypoint in exit_waypoints:
-            for entry_waypoint in entry_waypoints:
-                if exit_waypoint.lane() is not entry_waypoint.lane() and \
-                   lane_pairs[exit_waypoint.lane()][entry_waypoint.lane()] is None:
-
-                    if not exit_waypoint.center().almost_equal_to(entry_waypoint.center(), 5):
-                        primitive = self._geometry_class.connect(exit_waypoint, entry_waypoint)
-
-                        if primitive.is_valid_path_connection() or not strict:
-                            connection = WaypointConnection(exit_waypoint, entry_waypoint, primitive)
-                            lane_pairs[exit_waypoint.lane()][entry_waypoint.lane()] = connection
-
-    def _fulfill_intersection_with_single_length(self):
-        radius_candidates = [5.0, 5.5, 6.0, 4.5, 6.5]
+    def _fulfill_intersection_with_single_length(self, lane_pairs):
+        radius_candidates = [5.0, 5.5, 6.0, 4.5, 6.5, 7.0]
         for radius in radius_candidates:
             try:
-                return self._fulfill_intersection_with_circle_of_radius(radius)
+                lane_pairs_copy = lane_pairs.copy()
+                return self._fulfill_intersections_with_circle_of_radius(radius, lane_pairs)
             except JunctionNotSatisfied:
                 pass
         raise JunctionNotSatisfied()
 
-    def _fulfill_intersection_with_circle_of_radius(self, radius):
-        try:
-            intersections = self._create_lane_intersections_mapping(radius)
-        except IntersectionNotFound:
-            raise JunctionNotSatisfied()
+    def _fulfill_intersections_with_circle_of_radius(self, radius, lane_pairs):
+        return self._create_lane_intersections(radius, lane_pairs).values()
 
-        waypoints = self._get_waypoints_for_intersections(intersections)
-        exit_waypoints, entry_waypoints = self._split_exit_entry_waypoints(waypoints)
-
-        connections = []
-
-        for exit_waypoint in exit_waypoints:
-            for entry_waypoint in entry_waypoints:
-                if exit_waypoint.lane() is not entry_waypoint.lane():
-
-                    if exit_waypoint.center().almost_equal_to(entry_waypoint.center(), 5):
-                        raise JunctionNotSatisfied()
-
-                    primitive = self._geometry_class.connect(exit_waypoint, entry_waypoint)
-
-                    if not primitive or not primitive.is_valid_path_connection():
-                        raise JunctionNotSatisfied()
-
-                    connections.append(WaypointConnection(exit_waypoint, entry_waypoint, primitive))
-
-        return connections
-
-    def _create_lane_intersections_mapping(self, radius, check_count=True):
-        lane_intersections = OrderedDict()
+    def _create_lane_intersections(self, radius, lane_pairs, strict=True):
+        intersections = OrderedDict()
+        mapped_intersection_center = self.mapped_intersection_center()
         intersection_center = self.intersection_center()
         circle = Circle(intersection_center, radius)
         node = self._road_node
@@ -201,47 +126,113 @@ class JunctionBuilder(object):
             path = lane.path_for(self._geometry_class)
             path_intersections = path.find_intersection(circle)
 
-            if (path.starts_on(intersection_center) and path.ends_on(intersection_center)) or \
-               (not path.starts_on(intersection_center) and not path.ends_on(intersection_center)):
-                expected_intersections = 2
-            else:
-                expected_intersections = 1
-
             indexed_intersections = OrderedDict()
             for intersection in path_intersections:
-                point = intersection.closest_point_to(intersection_center)
+                point = intersection.closest_point_to(mapped_intersection_center)
                 rounded_point = point.rounded_to(7)
                 indexed_intersections[rounded_point] = point
             path_intersections = indexed_intersections.values()
-            if check_count and (len(path_intersections) is not expected_intersections):
-                raise IntersectionNotFound("Intersections mismatch. Expecting {0} but found {1}".format(expected_intersections, path_intersections))
-            lane_intersections[lane] = path_intersections
-        return lane_intersections
+            intersections[lane] = self._get_waypoints_for_intersections(lane, path_intersections)
 
-    def _get_waypoints_for_intersections(self, intersection_points):
+        for (exit_lane, entry_lane) in lane_pairs.keys():
+            exit_waypoint = None
+            entry_waypoint = None
+            try:
+                exit_waypoint = self._get_exit_waypoint_from_intersections(intersections[exit_lane])
+                entry_waypoint = self._get_entry_waypoint_from_intersections(intersections[entry_lane])
+            # TODO: Improve this way of handling errors
+            except RuntimeError as error:
+                if strict:
+                    raise JunctionNotSatisfied()
+
+            if exit_waypoint and entry_waypoint:
+
+                if exit_waypoint.center().almost_equal_to(entry_waypoint.center(), 5):
+                    raise JunctionNotSatisfied()
+
+                primitive = self._geometry_class.connect(exit_waypoint, entry_waypoint)
+
+                if strict and (not primitive or not primitive.is_valid_path_connection()):
+                    raise JunctionNotSatisfied()
+
+                if primitive:
+                    lane_pairs[(exit_lane, entry_lane)] = WaypointConnection(exit_waypoint, entry_waypoint, primitive)
+
+        return lane_pairs
+
+    def _get_waypoints_for_intersections(self, lane, points):
         new_waypoints = OrderedDict()
         waypoints = []
-        for lane, points in intersection_points.iteritems():
-            for point in points:
-                geometry = lane._lane_geometry(self._geometry_class)
-                path = lane.path_for(self._geometry_class)
-                waypoint = geometry.waypoint_at_point(point)
-                if not waypoint:
-                    heading = path.heading_at_point(point)
-                    waypoint = Waypoint(lane, point, heading, self._road_node)
-                    new_waypoints[(lane, point.rounded_to(5))] = waypoint
-                waypoints.append(waypoint)
+        for point in points:
+            geometry = lane._lane_geometry(self._geometry_class)
+            path = lane.path_for(self._geometry_class)
+            waypoint = geometry.waypoint_at_point(point)
+            if not waypoint:
+                heading = path.heading_at_point(point)
+                waypoint = Waypoint(lane, point, heading, self._road_node)
+                new_waypoints[(lane, point.rounded_to(5))] = waypoint
+            waypoints.append(waypoint)
         return waypoints
 
-    def _split_exit_entry_waypoints(self, waypoints):
-        exit_waypoints = []
-        entry_waypoints = []
-        for waypoint in waypoints:
+    def _get_exit_waypoint_from_intersections(self, intersections):
+        for waypoint in intersections:
             heading_vector = waypoint.heading_vector()
-            waypoint_to_intersection = self.intersection_center() - waypoint.center()
+            waypoint_to_intersection = self.mapped_intersection_center() - waypoint.center()
+            if waypoint_to_intersection.norm_squared() < 1e-2:
+                raise RuntimeError("Too close")
             angle = heading_vector.angle(waypoint_to_intersection)
             if abs(angle) < 90.0:
-                exit_waypoints.append(waypoint)
+                return waypoint
+        raise RuntimeError("Expecting to find intersection")
+
+    def _get_entry_waypoint_from_intersections(self, intersections):
+        for waypoint in intersections:
+            heading_vector = waypoint.heading_vector()
+            waypoint_to_intersection = self.mapped_intersection_center() - waypoint.center()
+            if waypoint_to_intersection.norm_squared() < 1e-2:
+                raise RuntimeError("Too close")
+            angle = heading_vector.angle(waypoint_to_intersection)
+            if abs(angle) >= 90.0:
+                return waypoint
+        raise RuntimeError("Expecting to find intersection")
+
+    def _fulfill_intersection_with_adaptive_approach(self, lane_pairs):
+        up = [x / 2.0 for x in range(10, 31)]  # [5.0, 5.5, 6.0, ...]
+        down = [x / 2.0 for x in reversed(range(1, 10))]  # [4.5, 4.0, ...]
+        radius_candidates = up + down
+        lane_pairs_copy = lane_pairs.copy()
+
+        for radius in radius_candidates:
+            lane_pairs_copy = self._fill_missing_connections(radius, lane_pairs_copy, True)
+
+        for radius in radius_candidates:
+            lane_pairs_copy = self._fill_missing_connections(radius, lane_pairs_copy, False)
+
+        connections = []
+
+        for (exit_lane, entry_lane), connection in lane_pairs_copy.iteritems():
+            if connection:
+                connections.append(connection)
             else:
-                entry_waypoints.append(waypoint)
-        return (exit_waypoints, entry_waypoints)
+                logger.warn("Missing connection between {0} and {1}".format(exit_lane, entry_lane))
+
+        return connections
+
+    def _fill_missing_connections(self, radius, lane_pairs, strict):
+        missing_connections = OrderedDict()
+        for lanes, connection in lane_pairs.iteritems():
+            if connection is None:
+                missing_connections[lanes] = None
+
+        if not missing_connections:
+            return lane_pairs
+
+        try:
+            new_connections = self._create_lane_intersections(radius, missing_connections, strict)
+            for lanes, connection in new_connections.iteritems():
+                if connection is not None:
+                    lane_pairs[lanes] = connection
+            return lane_pairs
+
+        except JunctionNotSatisfied:
+            return lane_pairs

--- a/terminus/models/lane.py
+++ b/terminus/models/lane.py
@@ -27,11 +27,15 @@ from waypoint_geometry import WaypointGeometry
 
 
 class Lane(object):
-    def __init__(self, road, width, offset):
+    def __init__(self, road, width, offset, reversed):
         self._road = road
         self._width = width
         self._offset = offset
+        self._reversed = reversed
         self._cached_geometries = {}
+
+    def is_reversed(self):
+        return self._reversed
 
     def offset(self):
         return self._offset
@@ -50,10 +54,13 @@ class Lane(object):
         return self._road
 
     def road_nodes(self):
-        return self.road().nodes()
+        if self._reversed:
+            return self.road().nodes()[::-1]
+        else:
+            return self.road().nodes()
 
     def road_nodes_count(self):
-        return self.road().node_count()
+        return len(self.road_nodes())
 
     def waypoints_for(self, geometry_class):
         return self._lane_geometry(geometry_class).waypoints()

--- a/terminus/models/polyline_geometry.py
+++ b/terminus/models/polyline_geometry.py
@@ -24,7 +24,7 @@ from lane_geometry import LaneGeometry
 class PolylineGeometry(LaneGeometry):
 
     @classmethod
-    def build_path_and_waypoints(cls, lane):
+    def build_path_and_waypoints(cls, lane, mapped_centers):
         if lane.road_nodes_count() < 2:
             raise ValueError("At least two nodes are required to build a geometry")
 
@@ -33,8 +33,8 @@ class PolylineGeometry(LaneGeometry):
         path = Path()
         waypoints = []
         for start_node, end_node in node_pairs:
-            start_point = start_node.center
-            end_point = end_node.center
+            start_point = mapped_centers[start_node]
+            end_point = mapped_centers[end_node]
             segment = LineSegment(start_point, end_point)
             path.add_element(segment)
             waypoints.append(cls._new_waypoint(lane, segment, start_node))

--- a/terminus/models/road.py
+++ b/terminus/models/road.py
@@ -103,8 +103,8 @@ class Road(CityModel):
 
     # Lane management
 
-    def add_lane(self, offset, width=4):
-        self._lanes.append(Lane(self, width, offset))
+    def add_lane(self, offset, width=4, reversed=False):
+        self._lanes.append(Lane(self, width, offset, reversed))
 
     def lane_count(self):
         return len(self._lanes)

--- a/terminus/models/trunk.py
+++ b/terminus/models/trunk.py
@@ -21,7 +21,7 @@ class Trunk(Road):
     def __init__(self, name=None):
         super(Trunk, self).__init__(name)
         self.add_lane(2)
-        self.add_lane(-2)
+        self.add_lane(-2, reversed=True)
 
     def accept(self, generator):
         generator.start_trunk(self)

--- a/terminus/models/trunk.py
+++ b/terminus/models/trunk.py
@@ -20,8 +20,8 @@ from road import Road
 class Trunk(Road):
     def __init__(self, name=None):
         super(Trunk, self).__init__(name)
-        self.add_lane(2)
-        self.add_lane(-2, reversed=True)
+        self.add_lane(2, reversed=True)
+        self.add_lane(-2)
 
     def accept(self, generator):
         generator.start_trunk(self)

--- a/terminus/tests/monolane_generator_test.py
+++ b/terminus/tests/monolane_generator_test.py
@@ -46,7 +46,7 @@ class MonolaneGeneratorTest(unittest.TestCase):
           id: {0}
           lane_bounds: [-2, 2]
           driveable_bounds: [-4, 4]
-          position_precision: 0.0005
+          position_precision: 0.01
           orientation_precision: 0.5{1}\n""".format(name, expected_core_contents)
         expected = textwrap.dedent(expected_contents)[1:]
         self.assertMultiLineEqual(self.generated_contents, expected)


### PR DESCRIPTION
In this PR:

- Define initial support for path offseting.
- Generate trunks for all the builders (multilane on OSM needs further analysis based on the different types of roads and the number of lanes. This will be tackled in another issue).
- File generation ok in both Simple Cicy and PCG. OSM requires some further tuning.